### PR TITLE
Add initial combat scriptable objects and editor

### DIFF
--- a/Assets/Editor/BattleEditorWindow.cs
+++ b/Assets/Editor/BattleEditorWindow.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using AdventuresOfBlink.Combat;
+using AdventuresOfBlink.Data;
+
+namespace AdventuresOfBlink.Editor
+{
+    /// <summary>
+    /// Basic editor window for inspecting abilities and combos.
+    /// This is an early tool that can be extended for timing and fine-tuning.
+    /// </summary>
+    public class BattleEditorWindow : EditorWindow
+    {
+        private AbilityData selectedAbility;
+        private ComboSequence selectedCombo;
+
+        [MenuItem("Blink Tools/Battle Editor")]
+        public static void ShowWindow()
+        {
+            GetWindow<BattleEditorWindow>("Battle Editor");
+        }
+
+        private void OnGUI()
+        {
+            GUILayout.Label("Ability", EditorStyles.boldLabel);
+            selectedAbility = (AbilityData)EditorGUILayout.ObjectField("Selected Ability", selectedAbility, typeof(AbilityData), false);
+            if (selectedAbility != null)
+            {
+                DrawAbility(selectedAbility);
+            }
+
+            GUILayout.Space(10);
+            GUILayout.Label("Combo", EditorStyles.boldLabel);
+            selectedCombo = (ComboSequence)EditorGUILayout.ObjectField("Selected Combo", selectedCombo, typeof(ComboSequence), false);
+            if (selectedCombo != null)
+            {
+                DrawCombo(selectedCombo);
+            }
+        }
+
+        private void DrawAbility(AbilityData ability)
+        {
+            EditorGUILayout.LabelField("Name", ability.abilityName);
+            EditorGUILayout.FloatField("Base Damage", ability.baseDamage);
+            EditorGUILayout.FloatField("Cooldown", ability.cooldown);
+            EditorGUILayout.ObjectField("Animation", ability.animationClip, typeof(AnimationClip), false);
+        }
+
+        private void DrawCombo(ComboSequence combo)
+        {
+            EditorGUILayout.FloatField("Input Window", combo.inputWindow);
+            for (int i = 0; i < combo.steps.Count; i++)
+            {
+                combo.steps[i] = (AbilityData)EditorGUILayout.ObjectField($"Step {i + 1}", combo.steps[i], typeof(AbilityData), false);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Combat/BattleFormula.cs
+++ b/Assets/Scripts/Combat/BattleFormula.cs
@@ -1,0 +1,18 @@
+using AdventuresOfBlink.Data;
+
+namespace AdventuresOfBlink.Combat
+{
+    /// <summary>
+    /// Static helper containing the game's damage and defense calculations.
+    /// Adjust constants here or expose them via the editor.
+    /// </summary>
+    public static class BattleFormula
+    {
+        public static float CalculateDamage(CharacterStats attacker, CharacterStats defender, AbilityData ability)
+        {
+            float attackPower = attacker.attack + ability.baseDamage;
+            float damage = attackPower - defender.defense;
+            return UnityEngine.Mathf.Max(1f, damage);
+        }
+    }
+}

--- a/Assets/Scripts/Combat/ComboSequence.cs
+++ b/Assets/Scripts/Combat/ComboSequence.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AdventuresOfBlink.Combat
+{
+    /// <summary>
+    /// Defines a sequence of abilities that form a combo attack.
+    /// </summary>
+    [CreateAssetMenu(fileName = "ComboSequence", menuName = "AdventuresOfBlink/Combo Sequence", order = 3)]
+    public class ComboSequence : ScriptableObject
+    {
+        public List<AbilityData> steps = new List<AbilityData>();
+
+        [Tooltip("Time in seconds within which the next input must occur.")]
+        public float inputWindow = 0.5f;
+    }
+}

--- a/Assets/Scripts/Data/AbilityData.cs
+++ b/Assets/Scripts/Data/AbilityData.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.Data
+{
+    /// <summary>
+    /// Describes an ability that Blink or other characters can perform.
+    /// Stored as a ScriptableObject for easy editing in the Unity Inspector.
+    /// </summary>
+    [CreateAssetMenu(fileName = "AbilityData", menuName = "AdventuresOfBlink/Ability", order = 0)]
+    public class AbilityData : ScriptableObject
+    {
+        [Header("Basic Info")]
+        public string abilityName;
+        public Sprite icon;
+        [TextArea]
+        public string description;
+
+        [Header("Input")]
+        [Tooltip("Keyboard slot index 0-9 for quick access. -1 means unassigned.")]
+        public int keyboardSlot = -1;
+
+        [Tooltip("Optional input action name for controller profiles.")]
+        public string inputAction;
+
+        [Header("Combat")]
+        public float baseDamage = 1f;
+        public float cooldown = 0f;
+        public AnimationClip animationClip;
+    }
+}

--- a/Assets/Scripts/Data/CharacterStats.cs
+++ b/Assets/Scripts/Data/CharacterStats.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.Data
+{
+    /// <summary>
+    /// Base stats for a character or enemy.
+    /// These can be extended with equipment or buffs.
+    /// </summary>
+    [CreateAssetMenu(fileName = "CharacterStats", menuName = "AdventuresOfBlink/Character Stats", order = 2)]
+    public class CharacterStats : ScriptableObject
+    {
+        public int maxHealth = 100;
+        public int attack = 10;
+        public int defense = 5;
+        public int speed = 5;
+    }
+}

--- a/Assets/Scripts/Data/ItemData.cs
+++ b/Assets/Scripts/Data/ItemData.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.Data
+{
+    /// <summary>
+    /// Represents an item that can be used in or out of battle.
+    /// </summary>
+    [CreateAssetMenu(fileName = "ItemData", menuName = "AdventuresOfBlink/Item", order = 1)]
+    public class ItemData : ScriptableObject
+    {
+        [Header("Basic Info")]
+        public string itemName;
+        public Sprite icon;
+        [TextArea]
+        public string description;
+
+        [Header("Gameplay")]
+        public bool consumable = true;
+        public int maxStack = 1;
+    }
+}


### PR DESCRIPTION
## Summary
- establish initial battle data models for Abilities, Items, Stats, and Combo Sequences
- add static BattleFormula helper for damage calculations
- introduce `BattleEditorWindow` for viewing abilities and combos in the Unity editor

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684081af09e08328be5cba6444c5ef79