### PR TITLE
Initialize Unity 6.1 project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Unity generated files
+[Ll]ibrary/
+[Tt]emp/
+[Bb]uild/
+[Bb]uilds/
+[Ll]ogs/
+obj/
+*.csproj
+*.unityproj
+*.sln
+*.user
+*.userprefs
+*.pidb
+*.booproj
+*.svd
+*.pdb
+*.mdb
+*.opendb
+*.VC.db
+*.bak
+*.pidb.meta
+sysinfo.txt
+*.apk
+*.aab
+*.xcworkspace/
+*.xcuserstate
+.DS_Store
+.DS_Store?
+[Oo]bj/
+[Uu]ser[Ss]ettings/
+MemoryCaptures/
+AssetBundles/
+
+# Local settings
+.vscode/
+

--- a/Assets/Art/.gitkeep
+++ b/Assets/Art/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/Assets/Materials/.gitkeep
+++ b/Assets/Materials/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/Assets/Prefabs/.gitkeep
+++ b/Assets/Prefabs/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/Assets/Scenes/.gitkeep
+++ b/Assets/Scenes/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/Packages/.gitkeep
+++ b/Packages/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/ProjectSettings/.gitkeep
+++ b/ProjectSettings/.gitkeep
@@ -1,0 +1,1 @@
+placeholder

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # Adventures of Blink
 
-Adventures of Blink is a story-driven rogue-RPG built with **Unity 2022.3 LTS**. You play as Ben "Blink" Kade, a mild-mannered developer who becomes a code-wielding hero alongside his robotic min-pin Duke. Together they battle renegade programs and uncover the truth behind the mysterious AI known as Specter. Real-time combat, hacking puzzles and branching quests drive the adventure across five acts and an epilogue.
+Adventures of Blink is a rogue-RPG built in **Unity 6.1**. By day you are Ben "Blink" Kade, a UI programmer at DataWorks. By night you become the CodeWarrior Blink, a vigilante who uses a custom shader implant to hide his identity and augment his senses. With help from Duke, a robotic min-pin companion, Blink hunts hostile hologram programs that threaten DataCity and the Zenith A.I. that keeps it stable.
 
-## Game Concept
-Blink's journey spans Data City, from underground clubs to virtual reality theaters. Allies such as Eli Ramirez and Dr. Cass Vale provide help, while hostile utilities like Splice, Loop and Mutex threaten the city. Choices influence relationships and unlock side content, culminating in the unification of forgotten code.
+The project is in early setup. The vision includes hack-and-slash battles with a plasma sword, a companion ability system for Duke, a macOS-style dock for quick items and skills, weather effects, and upgrades for Blink's implant and Duke's parts. Movement will support WSAD or mouse input, with combo attacks triggered by timing.
 
-### Story Arc
-The campaign unfolds over five main acts and a post-credits epilogue. Each act introduces new locations, bosses and side quests that expand the world and bring Blink closer to integrating Specter with Data City's systems.
-
-## Planned Directory Layout
-- `Assets/` – Core Unity assets
-- `Assets/Scripts/` – Game logic and behaviors
-- `Assets/Editor/` – Custom editor tools and utilities
-- `ProjectSettings/` – Unity configuration
+## Repository Layout
+- `Assets/` – Game assets and scripts
+  - `Editor/` – Custom Unity editor tools
+  - `Scripts/` – Gameplay code
+  - `Scenes/` – Unity scenes
+  - `Art/` – Artwork and textures
+  - `Prefabs/` – Prefab assets
+  - `Materials/` – Material definitions
+- `Packages/` – Unity package manifest
+- `ProjectSettings/` – Unity project settings
 
 ## Opening the Project
 1. Clone or download this repository.
 2. In Unity Hub, click **Add project** and select the cloned folder.
-3. Open with Unity **2022.3 LTS** to load the project.
+3. Open with **Unity 6.1**.
 
-Future editor tools will reside under `Assets/Editor`.
-
+Additional systems and tools will be added as development continues.


### PR DESCRIPTION
## Summary
- add Unity-specific `.gitignore`
- expand README with new backstory and setup instructions
- scaffold base directories for future scenes, art, prefabs, etc.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a22beffe08328b98bce500fd29d1a