### PR TITLE
Add inventory system and UI panels

### DIFF
--- a/Assets/Scripts/Systems/InventorySystem.cs
+++ b/Assets/Scripts/Systems/InventorySystem.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using UnityEngine;
+using AdventuresOfBlink.Data;
+
+namespace AdventuresOfBlink
+{
+    /// <summary>
+    /// Stores items and abilities collected by the player and manages
+    /// ability slots used by the dock shortcuts.
+    /// </summary>
+    public class InventorySystem : MonoBehaviour
+    {
+        [Header("Inventory")]
+        [Tooltip("List of items in the player's inventory.")]
+        public List<ItemEntry> items = new();
+
+        [Tooltip("Abilities acquired by the player.")]
+        public List<AbilityData> abilities = new();
+
+        [Header("Dock Slots")]
+        [Tooltip("Slots mapped to the dock for quick access.")]
+        public List<DockSlot> dockSlots = new();
+
+        /// <summary>
+        /// Adds an item to the inventory or increases the quantity if it exists.
+        /// </summary>
+        public void AddItem(ItemData item, int quantity = 1)
+        {
+            if (item == null)
+                return;
+
+            ItemEntry entry = items.Find(e => e.data == item);
+            if (entry != null)
+            {
+                entry.quantity += quantity;
+            }
+            else
+            {
+                items.Add(new ItemEntry { data = item, quantity = quantity });
+            }
+        }
+
+        /// <summary>
+        /// Removes an item and returns true if successful.
+        /// </summary>
+        public bool RemoveItem(ItemData item, int quantity = 1)
+        {
+            ItemEntry entry = items.Find(e => e.data == item);
+            if (entry == null || entry.quantity < quantity)
+                return false;
+
+            entry.quantity -= quantity;
+            if (entry.quantity <= 0)
+                items.Remove(entry);
+            return true;
+        }
+
+        /// <summary>
+        /// Equips an ability to a dock slot.
+        /// </summary>
+        public void EquipAbility(int dockIndex, AbilityData ability)
+        {
+            if (dockIndex < 0 || dockIndex >= dockSlots.Count)
+                return;
+
+            dockSlots[dockIndex].ability = ability;
+        }
+
+        [System.Serializable]
+        public class ItemEntry
+        {
+            public ItemData data;
+            public int quantity = 1;
+        }
+
+        [System.Serializable]
+        public class DockSlot
+        {
+            [Tooltip("Ability equipped to this slot.")]
+            public AbilityData ability;
+        }
+    }
+}

--- a/Assets/Scripts/UI/DockPanel.cs
+++ b/Assets/Scripts/UI/DockPanel.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+using AdventuresOfBlink.Data;
+
+namespace AdventuresOfBlink.UI
+{
+    /// <summary>
+    /// UI panel that displays abilities equipped to the dock shortcuts.
+    /// </summary>
+    public class DockPanel : MonoBehaviour
+    {
+        [Tooltip("Inventory system providing dock slot data.")]
+        public InventorySystem inventory;
+
+        [Tooltip("UI elements for each dock slot.")]
+        public DockSlotUI[] slots;
+
+        private void OnEnable()
+        {
+            Refresh();
+        }
+
+        /// <summary>
+        /// Updates each slot to match the inventory's dock assignments.
+        /// </summary>
+        public void Refresh()
+        {
+            if (inventory == null || slots == null)
+                return;
+
+            for (int i = 0; i < slots.Length; i++)
+            {
+                AbilityData ability = null;
+                if (i < inventory.dockSlots.Count)
+                    ability = inventory.dockSlots[i].ability;
+
+                if (slots[i] != null)
+                    slots[i].SetAbility(ability);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/DockSlotUI.cs
+++ b/Assets/Scripts/UI/DockSlotUI.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using UnityEngine.UI;
+using AdventuresOfBlink.Data;
+
+namespace AdventuresOfBlink.UI
+{
+    /// <summary>
+    /// Visual representation of a single dock slot.
+    /// </summary>
+    public class DockSlotUI : MonoBehaviour
+    {
+        [Tooltip("Image component displaying the ability icon.")]
+        public Image icon;
+
+        /// <summary>
+        /// Updates the icon based on the assigned ability.
+        /// </summary>
+        public void SetAbility(AbilityData ability)
+        {
+            if (icon == null)
+                return;
+
+            icon.sprite = ability != null ? ability.icon : null;
+            icon.enabled = ability != null;
+        }
+    }
+}

--- a/Assets/Scripts/UI/InventoryPanel.cs
+++ b/Assets/Scripts/UI/InventoryPanel.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.UI
+{
+    /// <summary>
+    /// UI panel that lists items from the player's inventory.
+    /// Items are populated under a content root using a prefab slot.
+    /// </summary>
+    public class InventoryPanel : MonoBehaviour
+    {
+        [Tooltip("Inventory system providing the data.")]
+        public InventorySystem inventory;
+
+        [Tooltip("Parent transform for generated item UI objects.")]
+        public Transform contentRoot;
+
+        [Tooltip("Prefab used for each item entry in the UI.")]
+        public GameObject itemSlotPrefab;
+
+        private void OnEnable()
+        {
+            Refresh();
+        }
+
+        /// <summary>
+        /// Rebuilds the item list based on the inventory contents.
+        /// </summary>
+        public void Refresh()
+        {
+            if (inventory == null || contentRoot == null || itemSlotPrefab == null)
+                return;
+
+            foreach (Transform child in contentRoot)
+                Destroy(child.gameObject);
+
+            foreach (var item in inventory.items)
+            {
+                GameObject go = Instantiate(itemSlotPrefab, contentRoot);
+                ItemSlotUI slot = go.GetComponent<ItemSlotUI>();
+                if (slot != null)
+                    slot.Setup(item.data, item.quantity);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/ItemSlotUI.cs
+++ b/Assets/Scripts/UI/ItemSlotUI.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using UnityEngine.UI;
+using AdventuresOfBlink.Data;
+
+namespace AdventuresOfBlink.UI
+{
+    /// <summary>
+    /// Displays a single item entry with icon and quantity text.
+    /// </summary>
+    public class ItemSlotUI : MonoBehaviour
+    {
+        public Image icon;
+        public Text quantityText;
+
+        /// <summary>
+        /// Initializes the slot visuals.
+        /// </summary>
+        public void Setup(ItemData data, int quantity)
+        {
+            if (icon != null)
+                icon.sprite = data != null ? data.icon : null;
+
+            if (quantityText != null)
+                quantityText.text = quantity.ToString();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The project is in early setup. The vision includes hack-and-slash battles with a
   - `Art/` – Artwork and textures
   - `Prefabs/` – Prefab assets
   - `Materials/` – Material definitions
+  - `Systems/` – Core runtime systems
 - `Packages/` – Unity package manifest
 - `ProjectSettings/` – Unity project settings
 
@@ -27,3 +28,4 @@ The project is in early setup. The vision includes hack-and-slash battles with a
 All gameplay assets and scripts will live under the `Assets/` folder. Subfolders such as `Scripts/` and `Art/` will grow as new systems are introduced.
 
 Additional systems and tools will be added as development continues.
+The new **InventorySystem** script tracks items and abilities and feeds data to UI panels, including the dock shortcut slots.

--- a/TASKS.md
+++ b/TASKS.md
@@ -14,7 +14,7 @@ Below is a high-level task list for implementing the features described in the p
 
 ## User Interface
 - [ ] Design the macOS-like dock with drag-and-drop shortcuts
-- [ ] Set up inventory and ability assignment to the dock
+- [x] Set up inventory and ability assignment to the dock
 
 ## World Systems
 - [ ] Integrate day/night cycle that toggles between Ben and Blink


### PR DESCRIPTION
## Summary
- create `InventorySystem` for tracking items, abilities, and dock slots
- add UI scripts to show inventory items and dock equip slots
- document the new system in README
- mark related task as completed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a91429dbc8328900974b868573cee