### PR TITLE
Add drag-and-drop dock prefab

### DIFF
--- a/Assets/Prefabs/Dock.prefab
+++ b/Assets/Prefabs/Dock.prefab
@@ -1,0 +1,248 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 22400000}
+  - component: {fileID: 22300000}
+  - component: {fileID: 11400000}
+  m_Layer: 5
+  m_Name: Dock
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &22400000
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1001}
+  - {fileID: 1002}
+  - {fileID: 1003}
+  - {fileID: 1004}
+  - {fileID: 1005}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!223 &22300000
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+  inventory: {fileID: 0}
+  slots:
+  - {fileID: 1141001}
+  - {fileID: 1141002}
+  - {fileID: 1141003}
+  - {fileID: 1141004}
+  - {fileID: 1141005}
+--- !u!1 &1001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2241001}
+  - component: {fileID: 2221001}
+  - component: {fileID: 1141001}
+  m_Layer: 5
+  m_Name: Slot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2241001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 1}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!222 &2221001
+Image:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001}
+  m_Sprite: {fileID: 0}
+  m_PreserveAspect: 1
+--- !u!114 &1141001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+  icon: {fileID: 2221001}
+  slotIndex: 0
+--- !u!1 &1002
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2241002}
+  - component: {fileID: 2221002}
+  - component: {fileID: 1141002}
+  m_Layer: 5
+  m_Name: Slot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2241002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 1}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!222 &2221002
+Image:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002}
+  m_Sprite: {fileID: 0}
+  m_PreserveAspect: 1
+--- !u!114 &1141002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+  icon: {fileID: 2221002}
+  slotIndex: 1
+--- !u!1 &1003
+GameObject:
+  m_Component:
+  - component: {fileID: 2241003}
+  - component: {fileID: 2221003}
+  - component: {fileID: 1141003}
+  m_Layer: 5
+  m_Name: Slot
+  m_IsActive: 1
+--- !u!224 &2241003
+RectTransform:
+  m_GameObject: {fileID: 1003}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 1}
+  m_RootOrder: 2
+--- !u!222 &2221003
+Image:
+  m_GameObject: {fileID: 1003}
+  m_Sprite: {fileID: 0}
+--- !u!114 &1141003
+MonoBehaviour:
+  m_GameObject: {fileID: 1003}
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+  icon: {fileID: 2221003}
+  slotIndex: 2
+--- !u!1 &1004
+GameObject:
+  m_Component:
+  - component: {fileID: 2241004}
+  - component: {fileID: 2221004}
+  - component: {fileID: 1141004}
+  m_Layer: 5
+  m_Name: Slot
+  m_IsActive: 1
+--- !u!224 &2241004
+RectTransform:
+  m_GameObject: {fileID: 1004}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 1}
+  m_RootOrder: 3
+--- !u!222 &2221004
+Image:
+  m_GameObject: {fileID: 1004}
+  m_Sprite: {fileID: 0}
+--- !u!114 &1141004
+MonoBehaviour:
+  m_GameObject: {fileID: 1004}
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+  icon: {fileID: 2221004}
+  slotIndex: 3
+--- !u!1 &1005
+GameObject:
+  m_Component:
+  - component: {fileID: 2241005}
+  - component: {fileID: 2221005}
+  - component: {fileID: 1141005}
+  m_Layer: 5
+  m_Name: Slot
+  m_IsActive: 1
+--- !u!224 &2241005
+RectTransform:
+  m_GameObject: {fileID: 1005}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 1}
+  m_RootOrder: 4
+--- !u!222 &2221005
+Image:
+  m_GameObject: {fileID: 1005}
+  m_Sprite: {fileID: 0}
+--- !u!114 &1141005
+MonoBehaviour:
+  m_GameObject: {fileID: 1005}
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+  icon: {fileID: 2221005}
+  slotIndex: 4

--- a/Assets/Prefabs/Dock.prefab.meta
+++ b/Assets/Prefabs/Dock.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 57a2110d5ddd4315a5bee7426c9e6f71
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Systems/InventorySystem.cs
+++ b/Assets/Scripts/Systems/InventorySystem.cs
@@ -64,6 +64,33 @@ namespace AdventuresOfBlink
                 return;
 
             dockSlots[dockIndex].ability = ability;
+            dockSlots[dockIndex].item = null;
+        }
+
+        /// <summary>
+        /// Equips an item to a dock slot.
+        /// </summary>
+        public void EquipItem(int dockIndex, ItemData data)
+        {
+            if (dockIndex < 0 || dockIndex >= dockSlots.Count)
+                return;
+
+            dockSlots[dockIndex].item = data;
+            if (data != null)
+                dockSlots[dockIndex].ability = null;
+        }
+
+        /// <summary>
+        /// Moves a dock slot entry from one index to another, preserving order.
+        /// </summary>
+        public void MoveDockSlot(int from, int to)
+        {
+            if (from < 0 || from >= dockSlots.Count || to < 0 || to >= dockSlots.Count)
+                return;
+
+            var entry = dockSlots[from];
+            dockSlots.RemoveAt(from);
+            dockSlots.Insert(to, entry);
         }
 
         [System.Serializable]
@@ -78,6 +105,9 @@ namespace AdventuresOfBlink
         {
             [Tooltip("Ability equipped to this slot.")]
             public AbilityData ability;
+
+            [Tooltip("Item equipped to this slot.")]
+            public ItemData item;
         }
     }
 }

--- a/Assets/Scripts/UI/DockPanel.cs
+++ b/Assets/Scripts/UI/DockPanel.cs
@@ -30,11 +30,18 @@ namespace AdventuresOfBlink.UI
             for (int i = 0; i < slots.Length; i++)
             {
                 AbilityData ability = null;
+                ItemData item = null;
                 if (i < inventory.dockSlots.Count)
+                {
                     ability = inventory.dockSlots[i].ability;
+                    item = inventory.dockSlots[i].item;
+                }
 
                 if (slots[i] != null)
-                    slots[i].SetAbility(ability);
+                {
+                    slots[i].slotIndex = i;
+                    slots[i].SetEntry(ability, item);
+                }
             }
         }
     }

--- a/Assets/Scripts/UI/DockSlotUI.cs
+++ b/Assets/Scripts/UI/DockSlotUI.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 using AdventuresOfBlink.Data;
 
 namespace AdventuresOfBlink.UI
@@ -7,21 +8,105 @@ namespace AdventuresOfBlink.UI
     /// <summary>
     /// Visual representation of a single dock slot.
     /// </summary>
-    public class DockSlotUI : MonoBehaviour
+    public class DockSlotUI : MonoBehaviour,
+        IBeginDragHandler, IEndDragHandler,
+        IDropHandler, IPointerEnterHandler, IPointerExitHandler
     {
-        [Tooltip("Image component displaying the ability icon.")]
+        [Tooltip("Image component displaying the ability or item icon.")]
         public Image icon;
 
-        /// <summary>
-        /// Updates the icon based on the assigned ability.
-        /// </summary>
-        public void SetAbility(AbilityData ability)
+        [Tooltip("Index of this slot within the dock.")]
+        public int slotIndex;
+
+        private AbilityData ability;
+        private ItemData item;
+
+        private Vector3 originalScale = Vector3.one;
+
+        private void Awake()
         {
+            originalScale = transform.localScale;
+        }
+
+        /// <summary>
+        /// Updates the icon based on the assigned ability or item.
+        /// </summary>
+        public void SetEntry(AbilityData newAbility, ItemData newItem)
+        {
+            ability = newAbility;
+            item = newItem;
+
             if (icon == null)
                 return;
 
-            icon.sprite = ability != null ? ability.icon : null;
-            icon.enabled = ability != null;
+            Sprite sprite = null;
+            if (ability != null)
+                sprite = ability.icon;
+            else if (item != null)
+                sprite = item.icon;
+
+            icon.sprite = sprite;
+            icon.enabled = sprite != null;
+        }
+
+        /// <summary>
+        /// Enlarges the slot icon on pointer hover for a dock magnification effect.
+        /// </summary>
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            transform.localScale = originalScale * 1.2f;
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            transform.localScale = originalScale;
+        }
+
+        /// <summary>
+        /// Begins dragging the current entry if one exists.
+        /// </summary>
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            if (ability == null && item == null)
+                return;
+
+            DragPayload.draggedAbility = ability;
+            DragPayload.draggedItem = item;
+            DragPayload.sourceSlot = this;
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+            DragPayload.Clear();
+        }
+
+        /// <summary>
+        /// Handles a drop onto this slot from another slot or the inventory.
+        /// Performs auto-rearranging when dragging between slots.
+        /// </summary>
+        public void OnDrop(PointerEventData eventData)
+        {
+            DockPanel panel = GetComponentInParent<DockPanel>();
+            if (panel == null || panel.inventory == null || !DragPayload.HasPayload)
+                return;
+
+            var inventory = panel.inventory;
+
+            if (DragPayload.sourceSlot != null)
+            {
+                int from = DragPayload.sourceSlot.slotIndex;
+                int to = slotIndex;
+                if (from != to)
+                    inventory.MoveDockSlot(from, to);
+            }
+            else
+            {
+                inventory.EquipAbility(slotIndex, DragPayload.draggedAbility);
+                inventory.EquipItem(slotIndex, DragPayload.draggedItem);
+            }
+
+            panel.Refresh();
+            DragPayload.Clear();
         }
     }
 }

--- a/Assets/Scripts/UI/DragPayload.cs
+++ b/Assets/Scripts/UI/DragPayload.cs
@@ -1,0 +1,30 @@
+using AdventuresOfBlink.Data;
+
+namespace AdventuresOfBlink.UI
+{
+    /// <summary>
+    /// Shared payload used during UI drag-and-drop operations.
+    /// Stores either an ability or item being dragged and the source slot.
+    /// </summary>
+    public static class DragPayload
+    {
+        public static AbilityData draggedAbility;
+        public static ItemData draggedItem;
+        public static DockSlotUI sourceSlot;
+
+        /// <summary>
+        /// Returns true if an item or ability is currently being dragged.
+        /// </summary>
+        public static bool HasPayload => draggedAbility != null || draggedItem != null;
+
+        /// <summary>
+        /// Clears the current drag payload.
+        /// </summary>
+        public static void Clear()
+        {
+            draggedAbility = null;
+            draggedItem = null;
+            sourceSlot = null;
+        }
+    }
+}

--- a/Assets/Scripts/UI/ItemSlotUI.cs
+++ b/Assets/Scripts/UI/ItemSlotUI.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 using AdventuresOfBlink.Data;
 
 namespace AdventuresOfBlink.UI
@@ -7,21 +8,42 @@ namespace AdventuresOfBlink.UI
     /// <summary>
     /// Displays a single item entry with icon and quantity text.
     /// </summary>
-    public class ItemSlotUI : MonoBehaviour
+    public class ItemSlotUI : MonoBehaviour, IBeginDragHandler, IEndDragHandler
     {
         public Image icon;
         public Text quantityText;
+
+        private ItemData itemData;
 
         /// <summary>
         /// Initializes the slot visuals.
         /// </summary>
         public void Setup(ItemData data, int quantity)
         {
+            itemData = data;
+
             if (icon != null)
                 icon.sprite = data != null ? data.icon : null;
 
             if (quantityText != null)
                 quantityText.text = quantity.ToString();
+        }
+
+        /// <summary>
+        /// Starts dragging this item, storing it in the shared drag payload.
+        /// </summary>
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            DragPayload.draggedItem = itemData;
+            DragPayload.sourceSlot = null;
+        }
+
+        /// <summary>
+        /// Clears the drag payload when dragging ends.
+        /// </summary>
+        public void OnEndDrag(PointerEventData eventData)
+        {
+            DragPayload.Clear();
         }
     }
 }


### PR DESCRIPTION
## Summary
- create `Dock.prefab` with dock slots under `Assets/Prefabs`
- add `DragPayload` helper for drag data
- enable dragging from inventory slots
- add hover magnification and dropping/reordering for dock slots
- allow both items and abilities in dock via `InventorySystem`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a922781b8832892a6e3ffda8cbd46