### PR TITLE
Implement day-night cycle and player form switching

### DIFF
--- a/Assets/Scripts/Player/PlayerFormSwitcher.cs
+++ b/Assets/Scripts/Player/PlayerFormSwitcher.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+using AdventuresOfBlink.Data;
+using AdventuresOfBlink.Systems;
+
+namespace AdventuresOfBlink.Player
+{
+    /// <summary>
+    /// Allows toggling between Ben and Blink forms at night.
+    /// Models and stats are swapped when the hotkey is pressed.
+    /// </summary>
+    public class PlayerFormSwitcher : MonoBehaviour
+    {
+        [Tooltip("Day/night cycle reference for time checks.")]
+        public DayNightCycle cycle;
+
+        [Header("Form Objects")]
+        [Tooltip("GameObject representing Ben.")]
+        public GameObject benModel;
+        [Tooltip("GameObject representing Blink.")]
+        public GameObject blinkModel;
+
+        [Header("Form Stats")]
+        public CharacterStats benStats;
+        public CharacterStats blinkStats;
+
+        [Tooltip("Active stats used by other systems.")]
+        public CharacterStats currentStats;
+
+        [Tooltip("Keyboard key used to switch forms.")]
+        public KeyCode switchKey = KeyCode.Tab;
+
+        private bool isBlink;
+#if ENABLE_INPUT_SYSTEM
+        private Key inputKey;
+#endif
+
+        private void Awake()
+        {
+#if ENABLE_INPUT_SYSTEM
+            inputKey = (Key)switchKey;
+#endif
+            SetForm(false);
+        }
+
+        private void Update()
+        {
+#if ENABLE_INPUT_SYSTEM
+            bool pressed = Keyboard.current != null && Keyboard.current[inputKey].wasPressedThisFrame;
+#else
+            bool pressed = Input.GetKeyDown(switchKey);
+#endif
+            if (pressed && cycle != null && cycle.IsNight)
+            {
+                SetForm(!isBlink);
+            }
+        }
+
+        private void SetForm(bool blink)
+        {
+            isBlink = blink;
+            if (benModel != null)
+                benModel.SetActive(!blink);
+            if (blinkModel != null)
+                blinkModel.SetActive(blink);
+            currentStats = blink ? blinkStats : benStats;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/DayNightCycle.cs
+++ b/Assets/Scripts/Systems/DayNightCycle.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.Systems
+{
+    /// <summary>
+    /// Manages the in-game time of day and updates scene lighting.
+    /// One full day lasts <see cref="dayLength"/> seconds and wraps
+    /// automatically. Color and intensity curves control the light.
+    /// </summary>
+    public class DayNightCycle : MonoBehaviour
+    {
+        [Tooltip("Directional light acting as the sun.")]
+        public Light sunLight;
+
+        [Tooltip("Gradient mapping time of day to light color.")]
+        public Gradient lightColor = new Gradient();
+
+        [Tooltip("Curve mapping time of day to light intensity.")]
+        public AnimationCurve lightIntensity = AnimationCurve.Linear(0f, 1f, 1f, 0f);
+
+        [Tooltip("Length of a full day in seconds.")]
+        public float dayLength = 300f;
+
+        [Tooltip("Current time of day normalized 0-1.")]
+        [Range(0f, 1f)]
+        public float timeOfDay;
+
+        /// <summary>
+        /// Returns true if the current time is considered nighttime.
+        /// </summary>
+        public bool IsNight => timeOfDay >= 0.5f;
+
+        private void Update()
+        {
+            timeOfDay += Time.deltaTime / Mathf.Max(1f, dayLength);
+            if (timeOfDay > 1f)
+                timeOfDay -= 1f;
+            UpdateLighting();
+        }
+
+        private void UpdateLighting()
+        {
+            if (sunLight == null)
+                return;
+
+            sunLight.color = lightColor.Evaluate(timeOfDay);
+            sunLight.intensity = lightIntensity.Evaluate(timeOfDay);
+            float angle = timeOfDay * 360f - 90f;
+            sunLight.transform.rotation = Quaternion.Euler(angle, 170f, 0f);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ All gameplay assets and scripts will live under the `Assets/` folder. Subfolders
 
 Additional systems and tools will be added as development continues.
 The new **InventorySystem** script tracks items and abilities and feeds data to UI panels, including the dock shortcut slots.
+The **DayNightCycle** manager controls lighting over time, and **PlayerFormSwitcher** lets you press Tab at night to toggle between Ben and Blink.


### PR DESCRIPTION
## Summary
- create `DayNightCycle` manager to animate sunlight and track time
- add `PlayerFormSwitcher` to toggle between Ben and Blink at night
- document the new systems in the README

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9458c6b0832884f230a9d7cb04fe