### PR TITLE
Implement upgrade system and UI

### DIFF
--- a/Assets/Scripts/Data/UpgradeData.cs
+++ b/Assets/Scripts/Data/UpgradeData.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.Data
+{
+    /// <summary>
+    /// Describes an upgrade that unlocks abilities or boosts stats.
+    /// </summary>
+    [CreateAssetMenu(fileName = "UpgradeData", menuName = "AdventuresOfBlink/Upgrade", order = 5)]
+    public class UpgradeData : ScriptableObject
+    {
+        [Header("Info")]
+        public string upgradeName;
+        public Sprite icon;
+        [TextArea]
+        public string description;
+
+        [Header("Requirements")]
+        public Requirement[] requirements;
+
+        [Header("Rewards")]
+        [Tooltip("Ability granted when the upgrade is applied.")]
+        public AbilityData abilityUnlock;
+        [Tooltip("Index of Duke ability to upgrade. -1 means none.")]
+        public int dukeAbilityIndex = -1;
+        [Tooltip("Stat boosts applied to Blink after upgrading.")]
+        public StatBoost statBoost;
+
+        [System.Serializable]
+        public class Requirement
+        {
+            public ItemData item;
+            public int amount = 1;
+        }
+
+        [System.Serializable]
+        public class StatBoost
+        {
+            public int health;
+            public int attack;
+            public int defense;
+            public int speed;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/UpgradeSystem.cs
+++ b/Assets/Scripts/Systems/UpgradeSystem.cs
@@ -1,0 +1,76 @@
+using UnityEngine;
+using AdventuresOfBlink.Data;
+using AdventuresOfBlink.Player;
+using AdventuresOfBlink.Companion;
+
+namespace AdventuresOfBlink.Systems
+{
+    /// <summary>
+    /// Consumes inventory materials to unlock new abilities or improve stats.
+    /// </summary>
+    public class UpgradeSystem : MonoBehaviour
+    {
+        [Tooltip("Inventory containing upgrade materials and abilities.")]
+        public InventorySystem inventory;
+
+        [Tooltip("Player form switcher used to access Blink stats.")]
+        public PlayerFormSwitcher playerForms;
+
+        [Tooltip("Duke controller for hardware upgrades.")]
+        public DukeController duke;
+
+        /// <summary>
+        /// Returns true if the inventory contains all required materials.
+        /// </summary>
+        public bool CanApply(UpgradeData upgrade)
+        {
+            if (upgrade == null || inventory == null)
+                return false;
+
+            if (upgrade.requirements != null)
+            {
+                foreach (var req in upgrade.requirements)
+                {
+                    if (req.item == null)
+                        continue;
+                    var entry = inventory.items.Find(e => e.data == req.item);
+                    if (entry == null || entry.quantity < req.amount)
+                        return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Attempts to consume materials and apply the upgrade effects.
+        /// </summary>
+        public bool ApplyUpgrade(UpgradeData upgrade)
+        {
+            if (!CanApply(upgrade))
+                return false;
+
+            if (upgrade.requirements != null)
+            {
+                foreach (var req in upgrade.requirements)
+                    inventory.RemoveItem(req.item, req.amount);
+            }
+
+            if (upgrade.abilityUnlock != null && !inventory.abilities.Contains(upgrade.abilityUnlock))
+                inventory.abilities.Add(upgrade.abilityUnlock);
+
+            if (upgrade.statBoost != null && playerForms != null && playerForms.blinkStats != null)
+            {
+                var stats = playerForms.blinkStats;
+                stats.maxHealth += upgrade.statBoost.health;
+                stats.attack += upgrade.statBoost.attack;
+                stats.defense += upgrade.statBoost.defense;
+                stats.speed += upgrade.statBoost.speed;
+            }
+
+            if (upgrade.dukeAbilityIndex >= 0 && duke != null)
+                duke.UpgradeAbility(upgrade.dukeAbilityIndex);
+
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/UI/UpgradeEntryUI.cs
+++ b/Assets/Scripts/UI/UpgradeEntryUI.cs
@@ -1,0 +1,75 @@
+using System.Text;
+using UnityEngine;
+using UnityEngine.UI;
+using AdventuresOfBlink.Data;
+using AdventuresOfBlink.Systems;
+
+namespace AdventuresOfBlink.UI
+{
+    /// <summary>
+    /// Displays a single upgrade option with purchase button.
+    /// </summary>
+    public class UpgradeEntryUI : MonoBehaviour
+    {
+        public Image icon;
+        public Text nameText;
+        public Text costText;
+        public Button upgradeButton;
+
+        private UpgradeData data;
+        private UpgradeSystem system;
+
+        /// <summary>
+        /// Initializes the UI for the specified upgrade.
+        /// </summary>
+        public void Setup(UpgradeData upgrade, UpgradeSystem upgradeSystem)
+        {
+            data = upgrade;
+            system = upgradeSystem;
+
+            if (icon != null)
+                icon.sprite = upgrade.icon;
+            if (nameText != null)
+                nameText.text = upgrade.upgradeName;
+            if (costText != null)
+                costText.text = BuildCostText();
+
+            if (upgradeButton != null)
+            {
+                upgradeButton.onClick.RemoveAllListeners();
+                upgradeButton.onClick.AddListener(TryUpgrade);
+            }
+        }
+
+        private string BuildCostText()
+        {
+            if (data.requirements == null)
+                return string.Empty;
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < data.requirements.Length; i++)
+            {
+                var req = data.requirements[i];
+                if (req.item != null)
+                {
+                    sb.Append(req.item.itemName);
+                    sb.Append(" x");
+                    sb.Append(req.amount);
+                    if (i < data.requirements.Length - 1)
+                        sb.Append(", ");
+                }
+            }
+            return sb.ToString();
+        }
+
+        private void TryUpgrade()
+        {
+            if (system != null && data != null)
+            {
+                bool success = system.ApplyUpgrade(data);
+                if (success && upgradeButton != null)
+                    upgradeButton.interactable = false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/UpgradePanel.cs
+++ b/Assets/Scripts/UI/UpgradePanel.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using AdventuresOfBlink.Systems;
+using AdventuresOfBlink.Data;
+
+namespace AdventuresOfBlink.UI
+{
+    /// <summary>
+    /// Displays available upgrades and allows the player to purchase them.
+    /// </summary>
+    public class UpgradePanel : MonoBehaviour
+    {
+        [Tooltip("Upgrade system used to apply upgrades.")]
+        public UpgradeSystem upgradeSystem;
+
+        [Tooltip("List of upgrades shown in this panel.")]
+        public UpgradeData[] availableUpgrades;
+
+        [Tooltip("Parent transform for generated entry UI objects.")]
+        public Transform contentRoot;
+
+        [Tooltip("Prefab used for each upgrade entry.")]
+        public GameObject entryPrefab;
+
+        private void OnEnable()
+        {
+            Refresh();
+        }
+
+        /// <summary>
+        /// Rebuilds the UI entries based on the available upgrades.
+        /// </summary>
+        public void Refresh()
+        {
+            if (contentRoot == null || entryPrefab == null || availableUpgrades == null)
+                return;
+
+            foreach (Transform child in contentRoot)
+                Destroy(child.gameObject);
+
+            foreach (var upg in availableUpgrades)
+            {
+                GameObject go = Instantiate(entryPrefab, contentRoot);
+                UpgradeEntryUI ui = go.GetComponent<UpgradeEntryUI>();
+                if (ui != null)
+                    ui.Setup(upg, upgradeSystem);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `UpgradeData` to describe material requirements and rewards
- create `UpgradeSystem` that unlocks abilities, boosts stats, and upgrades Duke
- add `UpgradePanel` and `UpgradeEntryUI` for interacting with upgrades

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a9a034ed483289acf795f44b9e308