### PR TITLE
Add neon shaders and guide updates

### DIFF
--- a/Assets/Documentation/SetupGuide.md
+++ b/Assets/Documentation/SetupGuide.md
@@ -45,3 +45,32 @@ This guide outlines how to configure core systems in **Adventures of Blink**. Fo
    - **duke** – the `DukeController` instance.
 
 Save this file inside the `Assets` folder so Unity imports it as a `TextAsset` and it can be viewed from the editor.
+
+## Rendering Pipeline and Post-Processing
+1. The project uses **Universal Render Pipeline (URP)**. Ensure the pipeline asset under `Assets/Settings/PC_RPAsset.asset` is assigned in **Graphics Settings**.
+2. Import the **Post Processing** package if it isn't already included.
+3. Create a global volume and assign `DefaultVolumeProfile.asset` for bloom, color grading and chromatic aberration. Enable bloom to accentuate neon lighting.
+
+## Neon Materials
+1. Two example shaders live in `Assets/Shaders`:
+   - `NeonGlow.shader` – simple unlit shader with emission.
+   - `HologramBarrier.shader` – transparent shader used for Blink's shield effect.
+2. Create materials that use these shaders and adjust the emission colors to taste.
+3. Assign the `NeonGlow` material to street lights or signs for a vibrant glow.
+
+## Blink Hologram Effect
+1. Add a `BlinkHologram` component to Blink's model.
+2. Set **Hologram Material** to a material that uses `HologramBarrier.shader`.
+3. Call `SetActive(true)` when Blink transforms to enable the barrier and `SetActive(false)` to return to the normal material.
+
+## Environment Prototyping
+1. Install the **ProBuilder** package from the package manager.
+2. Use ProBuilder shapes to block out buildings and streets. Save meshes to the `Assets/Models` folder for reuse.
+3. Example models `NeonSign.obj` and `WallPanel.obj` demonstrate simple planes for signage and walls.
+
+## Cinemachine Camera
+1. Add the **Cinemachine** package and create a `CinemachineVirtualCamera`.
+2. Set the virtual camera to follow and look at the player.
+3. You can still attach `CameraController` for manual orbiting while Cinemachine handles framing.
+
+Save this file inside the `Assets` folder so Unity imports it as a `TextAsset` and it can be viewed from the editor.

--- a/Assets/Models/NeonSign.obj
+++ b/Assets/Models/NeonSign.obj
@@ -1,0 +1,13 @@
+# Simple rectangular sign
+v -0.5 0 0
+v 0.5 0 0
+v -0.5 1 0
+v 0.5 1 0
+vt 0 0
+vt 1 0
+vt 0 1
+vt 1 1
+vn 0 0 1
+usemtl default
+s off
+f 1/1/1 2/2/1 4/4/1 3/3/1

--- a/Assets/Models/WallPanel.obj
+++ b/Assets/Models/WallPanel.obj
@@ -1,0 +1,13 @@
+# Simple wall plane
+v -0.5 0 0
+v 0.5 0 0
+v -0.5 1 0
+v 0.5 1 0
+vt 0 0
+vt 1 0
+vt 0 1
+vt 1 1
+vn 0 0 1
+usemtl default
+s off
+f 1/1/1 2/2/1 4/4/1 3/3/1

--- a/Assets/Scripts/Effects/BlinkHologram.cs
+++ b/Assets/Scripts/Effects/BlinkHologram.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.Effects
+{
+    /// <summary>
+    /// Applies the hologram barrier material to a mesh when Blink transforms.
+    /// The material should use the HologramBarrier shader.
+    /// </summary>
+    [RequireComponent(typeof(Renderer))]
+    public class BlinkHologram : MonoBehaviour
+    {
+        [Tooltip("Material using the HologramBarrier shader.")]
+        public Material hologramMaterial;
+
+        private Material originalMaterial;
+        private Renderer rend;
+
+        private void Awake()
+        {
+            rend = GetComponent<Renderer>();
+            originalMaterial = rend.sharedMaterial;
+        }
+
+        /// <summary>
+        /// Enables or disables the hologram effect.
+        /// </summary>
+        public void SetActive(bool active)
+        {
+            if (rend == null || hologramMaterial == null)
+                return;
+            rend.material = active ? hologramMaterial : originalMaterial;
+        }
+    }
+}

--- a/Assets/Shaders/HologramBarrier.shader
+++ b/Assets/Shaders/HologramBarrier.shader
@@ -1,0 +1,56 @@
+Shader "AdventuresOfBlink/HologramBarrier"
+{
+    Properties
+    {
+        _BaseColor ("Base Color", Color) = (0,1,1,0.2)
+        _LineColor ("Line Color", Color) = (0,1,1,0.8)
+        _LineFrequency ("Line Frequency", Float) = 20
+    }
+    SubShader
+    {
+        Tags { "Queue"="Transparent" "RenderType"="Transparent" "RenderPipeline"="UniversalRenderPipeline" }
+        LOD 100
+        ZWrite Off
+        Blend SrcAlpha OneMinusSrcAlpha
+
+        Pass
+        {
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+            };
+
+            struct Varyings
+            {
+                float4 positionHCS : SV_POSITION;
+                float3 positionWS : TEXCOORD0;
+            };
+
+            Varyings vert(Attributes v)
+            {
+                Varyings o;
+                o.positionHCS = TransformObjectToHClip(v.positionOS);
+                o.positionWS = TransformObjectToWorld(v.positionOS.xyz);
+                return o;
+            }
+
+            half4 _BaseColor;
+            half4 _LineColor;
+            float _LineFrequency;
+
+            half4 frag(Varyings i) : SV_Target
+            {
+                float line = step(0.5, frac(i.positionWS.x * _LineFrequency));
+                half alpha = lerp(_BaseColor.a, _LineColor.a, line);
+                half3 color = _BaseColor.rgb + line * _LineColor.rgb;
+                return half4(color, alpha);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/Shaders/HologramNoise.compute
+++ b/Assets/Shaders/HologramNoise.compute
@@ -1,0 +1,19 @@
+#pragma kernel CSMain
+
+RWTexture2D<float4> Result;
+
+uint Hash(uint x)
+{
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    return x;
+}
+
+[numthreads(8,8,1)]
+void CSMain (uint3 id : SV_DispatchThreadID)
+{
+    uint h = Hash(id.x + id.y * 73856093);
+    float n = (h & 0xFFFFu) / 65535.0;
+    Result[id.xy] = float4(n, n, n, 1);
+}

--- a/Assets/Shaders/NeonGlow.shader
+++ b/Assets/Shaders/NeonGlow.shader
@@ -1,0 +1,51 @@
+Shader "AdventuresOfBlink/NeonGlow"
+{
+    Properties
+    {
+        _BaseColor ("Base Color", Color) = (1,1,1,1)
+        _EmissionColor ("Emission Color", Color) = (0,1,1,1)
+        _EmissionStrength ("Emission Strength", Range(0,10)) = 1
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" "RenderPipeline"="UniversalRenderPipeline" }
+        LOD 100
+
+        Pass
+        {
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+            };
+
+            struct Varyings
+            {
+                float4 positionHCS : SV_POSITION;
+            };
+
+            Varyings vert(Attributes v)
+            {
+                Varyings o;
+                o.positionHCS = TransformObjectToHClip(v.positionOS);
+                return o;
+            }
+
+            half4 _BaseColor;
+            half4 _EmissionColor;
+            half _EmissionStrength;
+
+            half4 frag(Varyings i) : SV_Target
+            {
+                half3 col = _BaseColor.rgb;
+                half3 emission = _EmissionColor.rgb * _EmissionStrength;
+                return half4(col + emission, _BaseColor.a);
+            }
+            ENDHLSL
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create neon glow and hologram barrier shaders
- add compute shader for hologram noise
- add BlinkHologram script for applying shield material
- provide example OBJ meshes for sign and wall panels
- expand SetupGuide with rendering and environment instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b236776c88328bc229d37c08f5462