### PR TITLE
Add trigger volume system

### DIFF
--- a/Assets/Documentation/SetupGuide.md
+++ b/Assets/Documentation/SetupGuide.md
@@ -73,4 +73,12 @@ Save this file inside the `Assets` folder so Unity imports it as a `TextAsset` a
 2. Set the virtual camera to follow and look at the player.
 3. You can still attach `CameraController` for manual orbiting while Cinemachine handles framing.
 
+## Trigger Volumes
+1. Add a `TriggerVolume` component to a collider marked **Is Trigger**.
+2. Use **onPlayerEnter** and **onPlayerExit** to hook up reactions in the Inspector.
+3. `TeleportTrigger` moves the player to its **Target Location** when entered.
+4. `BoundaryTrigger` can push the player back or stop their movement.
+5. `SceneChangeTrigger` loads the specified scene using **Scene Name** on enter.
+6. `CutsceneTrigger` plays a Timeline via its **Playable Director** on enter.
+
 Save this file inside the `Assets` folder so Unity imports it as a `TextAsset` and it can be viewed from the editor.

--- a/Assets/Scripts/World/BoundaryTrigger.cs
+++ b/Assets/Scripts/World/BoundaryTrigger.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace AdventuresOfBlink.World
+{
+    /// <summary>
+    /// Boundary that optionally pushes the player back or stops movement when triggered.
+    /// </summary>
+    public class BoundaryTrigger : TriggerVolume
+    {
+        [Tooltip("If true the player will be pushed back on enter.")]
+        public bool pushPlayer = true;
+
+        [Tooltip("Distance to push the player when triggered.")]
+        public float pushDistance = 1f;
+
+        [Tooltip("If true the player's NavMeshAgent is stopped on enter.")]
+        public bool blockMovement;
+
+        protected override void OnTriggerEnter(Collider other)
+        {
+            base.OnTriggerEnter(other);
+            if (!other.CompareTag("Player"))
+                return;
+
+            if (blockMovement)
+            {
+                NavMeshAgent agent = other.GetComponent<NavMeshAgent>();
+                if (agent != null)
+                    agent.ResetPath();
+            }
+
+            if (pushPlayer)
+            {
+                Vector3 dir = other.transform.position - transform.position;
+                dir.y = 0f;
+                other.transform.position += dir.normalized * pushDistance;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/World/CutsceneTrigger.cs
+++ b/Assets/Scripts/World/CutsceneTrigger.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using UnityEngine.Playables;
+
+namespace AdventuresOfBlink.World
+{
+    /// <summary>
+    /// Plays a timeline cutscene when the player enters the trigger volume.
+    /// </summary>
+    public class CutsceneTrigger : TriggerVolume
+    {
+        [Tooltip("Timeline played when the player enters.")]
+        public PlayableDirector director;
+
+        protected override void OnTriggerEnter(Collider other)
+        {
+            base.OnTriggerEnter(other);
+            if (other.CompareTag("Player") && director != null)
+            {
+                director.Play();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/World/SceneChangeTrigger.cs
+++ b/Assets/Scripts/World/SceneChangeTrigger.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace AdventuresOfBlink.World
+{
+    /// <summary>
+    /// Loads the specified scene when the player enters the trigger volume.
+    /// </summary>
+    public class SceneChangeTrigger : TriggerVolume
+    {
+        [Tooltip("Name of the scene to load on enter.")]
+        public string sceneName;
+
+        protected override void OnTriggerEnter(Collider other)
+        {
+            base.OnTriggerEnter(other);
+            if (other.CompareTag("Player") && !string.IsNullOrEmpty(sceneName))
+            {
+                SceneManager.LoadScene(sceneName);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/World/TeleportTrigger.cs
+++ b/Assets/Scripts/World/TeleportTrigger.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.World
+{
+    /// <summary>
+    /// Teleports the player to a target location when entering the trigger.
+    /// </summary>
+    public class TeleportTrigger : TriggerVolume
+    {
+        [Tooltip("Destination transform to move the player to.")]
+        public Transform targetLocation;
+
+        protected override void OnTriggerEnter(Collider other)
+        {
+            base.OnTriggerEnter(other);
+            if (other.CompareTag("Player") && targetLocation != null)
+            {
+                other.transform.position = targetLocation.position;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/World/TriggerVolume.cs
+++ b/Assets/Scripts/World/TriggerVolume.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace AdventuresOfBlink.World
+{
+    /// <summary>
+    /// Base trigger volume that detects the player using OnTrigger events.
+    /// Requires a collider set as a trigger.
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public class TriggerVolume : MonoBehaviour
+    {
+        [Tooltip("Invoked when the player enters this volume.")]
+        public UnityEvent onPlayerEnter;
+
+        [Tooltip("Invoked when the player exits this volume.")]
+        public UnityEvent onPlayerExit;
+
+        private void Reset()
+        {
+            Collider col = GetComponent<Collider>();
+            if (col != null)
+                col.isTrigger = true;
+        }
+
+        protected virtual void OnTriggerEnter(Collider other)
+        {
+            if (other.CompareTag("Player"))
+                onPlayerEnter?.Invoke();
+        }
+
+        protected virtual void OnTriggerExit(Collider other)
+        {
+            if (other.CompareTag("Player"))
+                onPlayerExit?.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `TriggerVolume` base component that detects player entry
- add derived trigger types for teleporting, cutscenes, scene changes and boundaries
- document how to configure trigger volumes

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b29690bfc8328ad8b7fde3339adb0