### PR TITLE
Fix variable name in shader

### DIFF
--- a/Assets/Shaders/HologramBarrier.shader
+++ b/Assets/Shaders/HologramBarrier.shader
@@ -45,9 +45,9 @@ Shader "AdventuresOfBlink/HologramBarrier"
 
             half4 frag(Varyings i) : SV_Target
             {
-                float line = step(0.5, frac(i.positionWS.x * _LineFrequency));
-                half alpha = lerp(_BaseColor.a, _LineColor.a, line);
-                half3 color = _BaseColor.rgb + line * _LineColor.rgb;
+                float lineMask = step(0.5, frac(i.positionWS.x * _LineFrequency));
+                half alpha = lerp(_BaseColor.a, _LineColor.a, lineMask);
+                half3 color = _BaseColor.rgb + lineMask * _LineColor.rgb;
                 return half4(color, alpha);
             }
             ENDHLSL


### PR DESCRIPTION
## Summary
- rename the `line` variable to `lineMask` in *HologramBarrier.shader*

## Testing
- `glslangValidator -V -S frag Assets/Shaders/HologramBarrier.shader` *(fails: syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b39db7bc88328bca2ee5fe59e88e7