### PR TITLE
Add dock setup guide

### DIFF
--- a/Assets/Documentation/DockGuide.md
+++ b/Assets/Documentation/DockGuide.md
@@ -1,0 +1,17 @@
+# Dock Guide
+
+This guide explains how to add and configure the dock UI used for quick access to abilities and items.
+
+## Adding the Dock Prefab
+1. Locate **Dock.prefab** under `Assets/Prefabs` and drag it into your canvas or UI root.
+2. Select the root **Dock** object and in the **DockPanel** component assign your scene's `InventorySystem` to the **inventory** field.
+3. Expand the **slots** list on `DockPanel` and link each child `DockSlotUI` in order from left to right.
+4. Each child named *Slot* already has a `DockSlotUI` component with a preset `slotIndex`. Verify the indices start at `0` so the dock updates correctly.
+
+## Drag and Drop Behaviour
+1. `DockSlotUI` implements Unity drag interfaces and works together with the static `DragPayload` class.
+2. When dragging begins, the slot stores its ability or item in `DragPayload` along with a reference to the source slot.
+3. Dropping onto another slot calls `InventorySystem.MoveDockSlot` if the source was another dock slot, otherwise it equips the dragged entry using `EquipAbility` or `EquipItem`.
+4. The dock refreshes after each drop and `DragPayload.Clear()` is called to reset the payload when the drag ends.
+
+With the prefab placed and fields linked, the dock will display the current assignments from the inventory and support drag-and-drop rearranging.

--- a/Assets/Documentation/SetupGuide.md
+++ b/Assets/Documentation/SetupGuide.md
@@ -32,7 +32,7 @@ This guide outlines how to configure core systems in **Adventures of Blink**. Fo
 ## Inventory and UI
 1. Add an `InventorySystem` component to a persistent object (e.g. an empty `Managers` GameObject).
 2. Link UI panels to this inventory:
-   - **DockPanel** – set its `inventory` reference so dock slots reflect equipped items or abilities.
+   - **DockPanel** – set its `inventory` reference so dock slots reflect equipped items or abilities. See [Dock Guide](DockGuide.md) for detailed setup.
    - **InventoryPanel** – also assign the same `InventorySystem` for listing items.
    - **UpgradePanel** – requires an `UpgradeSystem` (see below) but will also reference the inventory through that system.
 


### PR DESCRIPTION
## Summary
- document how to place and configure the dock prefab
- describe drag and drop with `DockSlotUI` and `DragPayload`
- link the dock guide from the setup guide

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b45b3b20883289aeedae5dc0b5a05