### PR TITLE
Add edit mode test for InventorySystem

### DIFF
--- a/Assets/Tests/EditMode/InventorySystemTests.cs
+++ b/Assets/Tests/EditMode/InventorySystemTests.cs
@@ -1,0 +1,21 @@
+using NUnit.Framework;
+using UnityEngine;
+using AdventuresOfBlink;
+using AdventuresOfBlink.Data;
+
+public class InventorySystemTests
+{
+    [Test]
+    public void RemoveItem_ReturnsFalse_WhenQuantityExceedsInventory()
+    {
+        var gameObject = new GameObject("InventorySystem");
+        var inventory = gameObject.AddComponent<InventorySystem>();
+        var item = ScriptableObject.CreateInstance<ItemData>();
+        inventory.AddItem(item, 1);
+
+        bool result = inventory.RemoveItem(item, 2);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(1, inventory.items.Find(e => e.data == item).quantity);
+    }
+}

--- a/Assets/Tests/EditMode/Tests.EditMode.asmdef
+++ b/Assets/Tests/EditMode/Tests.EditMode.asmdef
@@ -1,0 +1,17 @@
+{
+  "name": "Tests.EditMode",
+  "references": [
+    "UnityEngine.TestRunner",
+    "UnityEditor.TestRunner"
+  ],
+  "optionalUnityReferences": [],
+  "includePlatforms": ["Editor"],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": false
+}


### PR DESCRIPTION
## Summary
- add edit mode assembly definition
- add `InventorySystemTests` to check `RemoveItem` return value when quantity is too high

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be22058bc83289f88a68dd7267664