### PR TITLE
Integrate PlayerInput actions

### DIFF
--- a/Assets/Documentation/SetupGuide.md
+++ b/Assets/Documentation/SetupGuide.md
@@ -13,9 +13,17 @@ This guide outlines how to configure core systems in **Adventures of Blink**. Fo
    - `CharacterController`
    - `NavMeshAgent`
    - `PlayerController`
+   - `PlayerInput` (assign `InputSystem_Actions` and set **Default Map** to `Player`)
 3. `PlayerController` exposes two main fields:
    - `moveSpeed` – movement speed when using the keyboard.
    - `rotationSpeed` – how quickly the character turns toward movement.
+4. Default controls using the **Player** action map:
+   - **Move** – WASD or left stick
+   - **Attack** – Left mouse button or gamepad west button
+   - **Interact** – `E` key or gamepad north button
+   - **Jump** – Space bar or gamepad south button
+   - **Crouch** – `C` key or gamepad east button
+   - **Sprint** – Left Shift or left stick press
 
 ## Camera
 1. Create a camera prefab or add a `CameraController` component to an existing camera.

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -11,6 +11,9 @@ namespace AdventuresOfBlink.Player
     /// Parameters are exposed so they can be tuned in the Unity Inspector.
     /// </summary>
     [RequireComponent(typeof(CharacterController))]
+#if ENABLE_INPUT_SYSTEM
+    [RequireComponent(typeof(PlayerInput))]
+#endif
     public class PlayerController : MonoBehaviour
     {
         [Header("Movement Settings")]
@@ -25,12 +28,29 @@ namespace AdventuresOfBlink.Player
         private Camera mainCamera;
 
         private Vector3 keyboardVelocity;
+#if ENABLE_INPUT_SYSTEM
+        private PlayerInput playerInput;
+        private InputAction moveAction;
+        private Vector2 moveInput;
+#endif
 
         private void Awake()
         {
             controller = GetComponent<CharacterController>();
             agent = GetComponent<NavMeshAgent>();
             mainCamera = Camera.main;
+#if ENABLE_INPUT_SYSTEM
+            playerInput = GetComponent<PlayerInput>();
+            if (playerInput != null)
+            {
+                moveAction = playerInput.actions["Move"];
+                if (moveAction != null)
+                {
+                    moveAction.performed += ctx => moveInput = ctx.ReadValue<Vector2>();
+                    moveAction.canceled += ctx => moveInput = Vector2.zero;
+                }
+            }
+#endif
 
             if (agent != null)
             {
@@ -48,14 +68,10 @@ namespace AdventuresOfBlink.Player
 
         private void HandleKeyboardMovement()
         {
-            Vector2 input = Vector2.zero;
 #if ENABLE_INPUT_SYSTEM
-            if (Keyboard.current != null)
-            {
-                input.x = (Keyboard.current.dKey.isPressed ? 1f : 0f) - (Keyboard.current.aKey.isPressed ? 1f : 0f);
-                input.y = (Keyboard.current.wKey.isPressed ? 1f : 0f) - (Keyboard.current.sKey.isPressed ? 1f : 0f);
-            }
+            Vector2 input = moveInput;
 #else
+            Vector2 input = Vector2.zero;
             input.x = Input.GetAxisRaw("Horizontal");
             input.y = Input.GetAxisRaw("Vertical");
 #endif

--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ All gameplay assets and scripts will live under the `Assets/` folder. Subfolders
 Additional systems and tools will be added as development continues.
 The new **InventorySystem** script tracks items and abilities and feeds data to UI panels, including the dock shortcut slots.
 The **DayNightCycle** manager controls lighting over time, and **PlayerFormSwitcher** lets you press Tab at night to toggle between Ben and Blink.
+
+## Controls
+The project uses the Input System with the `InputSystem_Actions` asset.
+Default bindings for the **Player** action map are:
+
+- **Move** – WASD or gamepad left stick
+- **Attack** – Left mouse button or gamepad west button
+- **Interact** – `E` key or gamepad north button
+- **Jump** – Space bar or gamepad south button
+- **Crouch** – `C` key or gamepad east button
+- **Sprint** – Left Shift or left stick press


### PR DESCRIPTION
## Summary
- hook up PlayerInput component in Player scripts
- drive PlasmaSword, PlayerController and PlayerHacking from action callbacks
- document default bindings

## Testing
- `npm --version`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685be40ed16c832884247475e96fc6c5