### PR TITLE
Add TextMeshPro package and reference

### DIFF
--- a/Assets/Scripts/AdventuresOfBlink.asmdef
+++ b/Assets/Scripts/AdventuresOfBlink.asmdef
@@ -2,7 +2,8 @@
   "name": "AdventuresOfBlink",
   "references": [
     "Unity.InputSystem",
-    "Unity.AI.Navigation"
+    "Unity.AI.Navigation",
+    "Unity.TextMeshPro"
   ],
   "optionalUnityReferences": [],
   "includePlatforms": [],

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,6 +9,7 @@
     "com.unity.render-pipelines.universal": "17.1.0",
     "com.unity.test-framework": "1.5.1",
     "com.unity.timeline": "1.8.7",
+    "com.unity.textmeshpro": "3.0.1",
     "com.unity.ugui": "2.0.0",
     "com.unity.visualscripting": "1.9.7",
     "com.unity.modules.accessibility": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -184,6 +184,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.textmeshpro": {
+      "version": "3.0.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.ugui": "2.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ugui": {
       "version": "2.0.0",
       "depth": 0,


### PR DESCRIPTION
## Summary
- include TextMeshPro in package manifest
- lock TextMeshPro package version
- reference Unity.TextMeshPro in the AdventuresOfBlink assembly

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bec1c3a70832888bbabbcacdc1e3e