### PR TITLE
Fix inventory changed event invocation

### DIFF
--- a/Assets/Scripts/Systems/InventorySystem.cs
+++ b/Assets/Scripts/Systems/InventorySystem.cs
@@ -27,6 +27,16 @@ namespace AdventuresOfBlink
         public event System.Action InventoryChanged;
 
         /// <summary>
+        /// Allows external systems to manually trigger the
+        /// <see cref="InventoryChanged"/> event after modifying
+        /// inventory contents.
+        /// </summary>
+        public void InvokeInventoryChanged()
+        {
+            InventoryChanged?.Invoke();
+        }
+
+        /// <summary>
         /// Adds an item to the inventory or increases the quantity if it exists.
         /// </summary>
         public void AddItem(ItemData item, int quantity = 1)

--- a/Assets/Scripts/Systems/SaveUtility.cs
+++ b/Assets/Scripts/Systems/SaveUtility.cs
@@ -134,7 +134,7 @@ namespace AdventuresOfBlink.Systems
                     duke.abilities[i].level = data.dukeLevels[i];
             }
 
-            inventory.InventoryChanged?.Invoke();
+            inventory.InvokeInventoryChanged();
         }
 
         [System.Serializable]


### PR DESCRIPTION
## Summary
- allow external callers to raise the `InventoryChanged` event
- update SaveUtility to invoke inventory change via method

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bee772d4c8328adc9784b635baab6