### PR TITLE
Introduce runtime stats

### DIFF
--- a/Assets/Documentation/UIPanelsGuide.md
+++ b/Assets/Documentation/UIPanelsGuide.md
@@ -37,7 +37,7 @@ This guide explains how to assemble and connect the user interface components in
 ## Health Bars
 1. To show floating health for characters, create a prefab with a `Slider` UI element.
 2. Add the `HealthBar` component.
-3. Assign the host's `CharacterStats` to **stats** and set **blinkTransform** to the player if visibility range is needed.
+3. Assign the host's `RuntimeStats` to **stats** and set **blinkTransform** to the player if visibility range is needed.
 4. Enable **alwaysVisible** to keep the bar displayed regardless of distance.
 
 Save this file inside the `Assets` folder so Unity imports it as a TextAsset.

--- a/Assets/Scripts/Combat/BattleFormula.cs
+++ b/Assets/Scripts/Combat/BattleFormula.cs
@@ -8,10 +8,10 @@ namespace AdventuresOfBlink.Combat
     /// </summary>
     public static class BattleFormula
     {
-        public static float CalculateDamage(CharacterStats attacker, CharacterStats defender, AbilityData ability)
+        public static float CalculateDamage(RuntimeStats attacker, RuntimeStats defender, AbilityData ability)
         {
-            float attackPower = attacker.attack + ability.baseDamage;
-            float damage = attackPower - defender.defense;
+            float attackPower = attacker.Attack + ability.baseDamage;
+            float damage = attackPower - defender.Defense;
             return UnityEngine.Mathf.Max(1f, damage);
         }
     }

--- a/Assets/Scripts/Combat/PlasmaSword.cs
+++ b/Assets/Scripts/Combat/PlasmaSword.cs
@@ -20,10 +20,10 @@ namespace AdventuresOfBlink.Combat
         public ComboSequence combo;
 
         [Tooltip("Stats of the attacker performing the combo.")]
-        public CharacterStats attacker;
+        public RuntimeStats attacker;
 
         [Tooltip("Optional stats of the current target receiving damage.")]
-        public CharacterStats target;
+        public RuntimeStats target;
 
         [Tooltip("Multiplier applied to attack speed from upgrades.")]
         public float speedMultiplier = 1f;
@@ -91,7 +91,7 @@ namespace AdventuresOfBlink.Combat
         {
             if (animator != null && ability.animationClip != null)
             {
-                float speed = (attacker != null ? attacker.speed : 1f) * speedMultiplier;
+                float speed = (attacker != null ? attacker.Speed : 1f) * speedMultiplier;
                 animator.speed = speed;
                 animator.Play(ability.animationClip.name);
             }

--- a/Assets/Scripts/Data/RuntimeStats.cs
+++ b/Assets/Scripts/Data/RuntimeStats.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.Data
+{
+    /// <summary>
+    /// Runtime copy of <see cref="CharacterStats"/> with additive and
+    /// percentage modifiers. Values are cloned from the source asset
+    /// when constructed so that scriptable objects remain unchanged.
+    /// </summary>
+    [System.Serializable]
+    public class RuntimeStats
+    {
+        public int baseMaxHealth;
+        public int baseAttack;
+        public int baseDefense;
+        public int baseSpeed;
+
+        [Header("Additive Modifiers")]
+        public int bonusMaxHealth;
+        public int bonusAttack;
+        public int bonusDefense;
+        public int bonusSpeed;
+
+        [Header("Percentage Modifiers")]
+        public float percentMaxHealth;
+        public float percentAttack;
+        public float percentDefense;
+        public float percentSpeed;
+
+        public RuntimeStats() { }
+
+        public RuntimeStats(CharacterStats source)
+        {
+            CopyFrom(source);
+        }
+
+        /// <summary>
+        /// Copies base values from a CharacterStats asset.
+        /// </summary>
+        public void CopyFrom(CharacterStats source)
+        {
+            if (source == null)
+                return;
+            baseMaxHealth = source.maxHealth;
+            baseAttack = source.attack;
+            baseDefense = source.defense;
+            baseSpeed = source.speed;
+        }
+
+        public int MaxHealth => Mathf.RoundToInt((baseMaxHealth + bonusMaxHealth) * (1f + percentMaxHealth));
+        public int Attack => Mathf.RoundToInt((baseAttack + bonusAttack) * (1f + percentAttack));
+        public int Defense => Mathf.RoundToInt((baseDefense + bonusDefense) * (1f + percentDefense));
+        public int Speed => Mathf.RoundToInt((baseSpeed + bonusSpeed) * (1f + percentSpeed));
+    }
+}

--- a/Assets/Scripts/Player/PlayerFormSwitcher.cs
+++ b/Assets/Scripts/Player/PlayerFormSwitcher.cs
@@ -23,11 +23,19 @@ namespace AdventuresOfBlink.Player
         public GameObject blinkModel;
 
         [Header("Form Stats")]
+        [Tooltip("Base stats asset for Ben.")]
         public CharacterStats benStats;
+        [Tooltip("Base stats asset for Blink.")]
         public CharacterStats blinkStats;
 
-        [Tooltip("Active stats used by other systems.")]
-        public CharacterStats currentStats;
+        [Tooltip("Runtime stats for the active form.")]
+        public RuntimeStats currentStats;
+
+        private RuntimeStats benRuntime;
+        private RuntimeStats blinkRuntime;
+
+        public RuntimeStats BenRuntime => benRuntime;
+        public RuntimeStats BlinkRuntime => blinkRuntime;
 
         [Tooltip("Keyboard key used to switch forms.")]
         public KeyCode switchKey = KeyCode.Tab;
@@ -42,6 +50,8 @@ namespace AdventuresOfBlink.Player
 #if ENABLE_INPUT_SYSTEM
             inputKey = (Key)switchKey;
 #endif
+            benRuntime = new RuntimeStats(benStats);
+            blinkRuntime = new RuntimeStats(blinkStats);
             SetForm(false);
         }
 
@@ -65,7 +75,7 @@ namespace AdventuresOfBlink.Player
                 benModel.SetActive(!blink);
             if (blinkModel != null)
                 blinkModel.SetActive(blink);
-            currentStats = blink ? blinkStats : benStats;
+            currentStats = blink ? blinkRuntime : benRuntime;
         }
     }
 }

--- a/Assets/Scripts/Systems/UpgradeSystem.cs
+++ b/Assets/Scripts/Systems/UpgradeSystem.cs
@@ -58,13 +58,13 @@ namespace AdventuresOfBlink.Systems
             if (upgrade.abilityUnlock != null && !inventory.abilities.Contains(upgrade.abilityUnlock))
                 inventory.abilities.Add(upgrade.abilityUnlock);
 
-            if (upgrade.statBoost != null && playerForms != null && playerForms.blinkStats != null)
+            if (upgrade.statBoost != null && playerForms != null && playerForms.BlinkRuntime != null)
             {
-                var stats = playerForms.blinkStats;
-                stats.maxHealth += upgrade.statBoost.health;
-                stats.attack += upgrade.statBoost.attack;
-                stats.defense += upgrade.statBoost.defense;
-                stats.speed += upgrade.statBoost.speed;
+                var stats = playerForms.BlinkRuntime;
+                stats.bonusMaxHealth += upgrade.statBoost.health;
+                stats.bonusAttack += upgrade.statBoost.attack;
+                stats.bonusDefense += upgrade.statBoost.defense;
+                stats.bonusSpeed += upgrade.statBoost.speed;
             }
 
             if (upgrade.dukeAbilityIndex >= 0 && duke != null)

--- a/Assets/Scripts/Targeting/Targetable.cs
+++ b/Assets/Scripts/Targeting/Targetable.cs
@@ -12,6 +12,6 @@ namespace AdventuresOfBlink.Targeting
         public string displayName;
 
         [Tooltip("Optional stats associated with this target.")]
-        public CharacterStats stats;
+        public RuntimeStats stats;
     }
 }

--- a/Assets/Scripts/UI/HealthBar.cs
+++ b/Assets/Scripts/UI/HealthBar.cs
@@ -14,7 +14,7 @@ namespace AdventuresOfBlink.UI
         public Slider slider;
 
         [Tooltip("Character stats providing max health.")]
-        public CharacterStats stats;
+        public RuntimeStats stats;
 
         [Tooltip("Current health value.")]
         public int currentHealth;
@@ -31,7 +31,7 @@ namespace AdventuresOfBlink.UI
         private void Awake()
         {
             if (stats != null)
-                currentHealth = stats.maxHealth;
+                currentHealth = stats.MaxHealth;
             UpdateBar();
         }
 
@@ -62,7 +62,7 @@ namespace AdventuresOfBlink.UI
         /// </summary>
         public void Heal(int amount)
         {
-            int max = stats != null ? stats.maxHealth : currentHealth;
+            int max = stats != null ? stats.MaxHealth : currentHealth;
             currentHealth = Mathf.Min(max, currentHealth + amount);
             UpdateBar();
         }
@@ -71,7 +71,7 @@ namespace AdventuresOfBlink.UI
         {
             if (slider == null)
                 return;
-            int max = stats != null ? stats.maxHealth : currentHealth;
+            int max = stats != null ? stats.MaxHealth : currentHealth;
             slider.value = max > 0 ? (float)currentHealth / max : 0f;
         }
     }


### PR DESCRIPTION
## Summary
- add `RuntimeStats` class for cloneable runtime data
- use `RuntimeStats` in PlayerFormSwitcher and combat systems
- handle upgrades by modifying runtime bonuses
- update HealthBar usage and documentation

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ccd5f1258832891548122851e8a31