### PR TITLE
Add CycleTarget action

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -85,6 +85,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "CycleTarget",
+                    "type": "Button",
+                    "id": "8a3d7a9b-f26b-42a0-a7dd-7d3011874130",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -470,6 +479,28 @@
                     "processors": "",
                     "groups": "Keyboard&Mouse",
                     "action": "Crouch",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b8878ab0-28f0-4d16-a484-69271f02ad72",
+                    "path": "<Keyboard>/tab",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "CycleTarget",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d5d4700f-e3e5-4ae1-ac7a-5320cd485091",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "CycleTarget",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scripts/Targeting/TargetingSystem.cs
+++ b/Assets/Scripts/Targeting/TargetingSystem.cs
@@ -8,6 +8,9 @@ namespace AdventuresOfBlink.Targeting
     /// <summary>
     /// Handles selecting and cycling between <see cref="Targetable"/> objects.
     /// </summary>
+    #if ENABLE_INPUT_SYSTEM
+    [RequireComponent(typeof(PlayerInput))]
+    #endif
     public class TargetingSystem : MonoBehaviour
     {
         /// <summary>
@@ -16,9 +19,8 @@ namespace AdventuresOfBlink.Targeting
         public Targetable CurrentTarget { get; private set; }
 
 #if ENABLE_INPUT_SYSTEM
-        [Tooltip("Input action used to cycle targets.")]
-        public InputActionReference cycleTargetAction;
-        private InputAction _cycleAction;
+        private PlayerInput playerInput;
+        private InputAction cycleAction;
 #endif
 
         /// <summary>
@@ -27,22 +29,28 @@ namespace AdventuresOfBlink.Targeting
         public event System.Action<Targetable> TargetChanged;
 
 #if ENABLE_INPUT_SYSTEM
+        private void Awake()
+        {
+            playerInput = GetComponent<PlayerInput>();
+            if (playerInput != null)
+                cycleAction = playerInput.actions["CycleTarget"];
+        }
+
         private void OnEnable()
         {
-            if (cycleTargetAction != null)
+            if (cycleAction != null)
             {
-                _cycleAction = cycleTargetAction.action;
-                _cycleAction.performed += OnCyclePerformed;
-                _cycleAction.Enable();
+                cycleAction.performed += OnCyclePerformed;
+                cycleAction.Enable();
             }
         }
 
         private void OnDisable()
         {
-            if (_cycleAction != null)
+            if (cycleAction != null)
             {
-                _cycleAction.performed -= OnCyclePerformed;
-                _cycleAction.Disable();
+                cycleAction.performed -= OnCyclePerformed;
+                cycleAction.Disable();
             }
         }
 #endif
@@ -50,7 +58,7 @@ namespace AdventuresOfBlink.Targeting
         private void Update()
         {
 #if ENABLE_INPUT_SYSTEM
-            if (_cycleAction == null)
+            if (cycleAction == null)
             {
                 bool pressed = Keyboard.current != null && Keyboard.current[Key.Tab].wasPressedThisFrame;
                 if (pressed)


### PR DESCRIPTION
## Summary
- add CycleTarget button action to Player input map
- allow Tab or right shoulder button to cycle targets
- hook TargetingSystem to PlayerInput actions instead of InputActionReference

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cce6e989883288bbcae5333421bdf