### PR TITLE
Add logic and energy stats

### DIFF
--- a/Assets/Scripts/Data/CharacterStats.cs
+++ b/Assets/Scripts/Data/CharacterStats.cs
@@ -13,5 +13,7 @@ namespace AdventuresOfBlink.Data
         public int attack = 10;
         public int defense = 5;
         public int speed = 5;
+        public int logic;
+        public int energy = 5;
     }
 }

--- a/Assets/Scripts/Data/RuntimeStats.cs
+++ b/Assets/Scripts/Data/RuntimeStats.cs
@@ -14,18 +14,24 @@ namespace AdventuresOfBlink.Data
         public int baseAttack;
         public int baseDefense;
         public int baseSpeed;
+        public int baseLogic;
+        public int baseEnergy;
 
         [Header("Additive Modifiers")]
         public int bonusMaxHealth;
         public int bonusAttack;
         public int bonusDefense;
         public int bonusSpeed;
+        public int bonusLogic;
+        public int bonusEnergy;
 
         [Header("Percentage Modifiers")]
         public float percentMaxHealth;
         public float percentAttack;
         public float percentDefense;
         public float percentSpeed;
+        public float percentLogic;
+        public float percentEnergy;
 
         public RuntimeStats() { }
 
@@ -45,11 +51,15 @@ namespace AdventuresOfBlink.Data
             baseAttack = source.attack;
             baseDefense = source.defense;
             baseSpeed = source.speed;
+            baseLogic = source.logic;
+            baseEnergy = source.energy;
         }
 
         public int MaxHealth => Mathf.RoundToInt((baseMaxHealth + bonusMaxHealth) * (1f + percentMaxHealth));
         public int Attack => Mathf.RoundToInt((baseAttack + bonusAttack) * (1f + percentAttack));
         public int Defense => Mathf.RoundToInt((baseDefense + bonusDefense) * (1f + percentDefense));
         public int Speed => Mathf.RoundToInt((baseSpeed + bonusSpeed) * (1f + percentSpeed));
+        public int Logic => Mathf.RoundToInt((baseLogic + bonusLogic) * (1f + percentLogic));
+        public int Energy => Mathf.RoundToInt((baseEnergy + bonusEnergy) * (1f + percentEnergy));
     }
 }

--- a/Assets/Scripts/Data/UpgradeData.cs
+++ b/Assets/Scripts/Data/UpgradeData.cs
@@ -39,6 +39,8 @@ namespace AdventuresOfBlink.Data
             public int attack;
             public int defense;
             public int speed;
+            public int logic;
+            public int energy;
         }
     }
 }

--- a/Assets/Scripts/Systems/UpgradeSystem.cs
+++ b/Assets/Scripts/Systems/UpgradeSystem.cs
@@ -65,6 +65,8 @@ namespace AdventuresOfBlink.Systems
                 stats.bonusAttack += upgrade.statBoost.attack;
                 stats.bonusDefense += upgrade.statBoost.defense;
                 stats.bonusSpeed += upgrade.statBoost.speed;
+                stats.bonusLogic += upgrade.statBoost.logic;
+                stats.bonusEnergy += upgrade.statBoost.energy;
             }
 
             if (upgrade.dukeAbilityIndex >= 0 && duke != null)


### PR DESCRIPTION
## Summary
- add `logic` and `energy` to `CharacterStats`
- extend `RuntimeStats` with logic and energy support
- support new stats in `UpgradeData` and `UpgradeSystem`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cceb7728883289f0b5fde1d1566fa