### PR TITLE
Add targeting system documentation

### DIFF
--- a/Assets/Documentation/SetupGuide.md
+++ b/Assets/Documentation/SetupGuide.md
@@ -37,6 +37,12 @@ This guide outlines how to configure core systems in **Adventures of Blink**. Fo
 2. Assign the player to the **target** field so Duke can follow.
 3. Populate the **Abilities** list with `DukeAbilityData` assets to define Duke's actions.
 
+## Targeting System
+1. Add a `TargetingSystem` component to the player or a persistent manager object.
+2. Attach `Targetable` to each enemy or NPC and set their **displayName** and optional `RuntimeStats`.
+3. Place `TargetPanel.prefab` under your canvas and assign its **targetingSystem** field.
+4. Press **Tab** in play mode to cycle between nearby targets. See [Targeting Guide](TargetingGuide.md) for full details.
+
 ## Inventory and UI
 1. Add an `InventorySystem` component to a persistent object (e.g. an empty `Managers` GameObject).
 2. Link UI panels to this inventory:

--- a/Assets/Documentation/TargetingGuide.md
+++ b/Assets/Documentation/TargetingGuide.md
@@ -1,0 +1,9 @@
+# Targeting Guide
+
+This guide explains how to configure the targeting system so the player can cycle between enemies and display their information in the UI.
+
+## Setup Steps
+1. Add the `TargetingSystem` component to your player or a persistent manager object.
+2. On each enemy or NPC, attach `Targetable` and fill in **displayName**. Assign a `RuntimeStats` reference if health should be displayed.
+3. Drag `TargetPanel.prefab` from `Assets/Prefabs` into your canvas and set its **targetingSystem** field.
+4. During play press the **Tab** key to cycle through nearby targets.


### PR DESCRIPTION
## Summary
- document how to set up the targeting system
- add section in SetupGuide referencing the new instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cd2e436748328ae955b2a2ef963e0