### PR TITLE
Implement energy cost for abilities

### DIFF
--- a/Assets/Scripts/Combat/PlasmaSword.cs
+++ b/Assets/Scripts/Combat/PlasmaSword.cs
@@ -89,6 +89,15 @@ namespace AdventuresOfBlink.Combat
 
         private void PerformAttack(AbilityData ability)
         {
+            if (attacker != null && ability.energyCost > 0)
+            {
+                if (!attacker.ConsumeEnergy(ability.energyCost))
+                {
+                    Debug.Log($"Not enough energy for {ability.abilityName}");
+                    return;
+                }
+            }
+
             if (animator != null && ability.animationClip != null)
             {
                 float speed = (attacker != null ? attacker.Speed : 1f) * speedMultiplier;

--- a/Assets/Scripts/Data/AbilityData.cs
+++ b/Assets/Scripts/Data/AbilityData.cs
@@ -24,6 +24,7 @@ namespace AdventuresOfBlink.Data
 
         [Header("Combat")]
         public float baseDamage = 1f;
+        public int energyCost = 0;
         public float cooldown = 0f;
         public AnimationClip animationClip;
     }

--- a/Assets/Scripts/Data/RuntimeStats.cs
+++ b/Assets/Scripts/Data/RuntimeStats.cs
@@ -25,6 +25,10 @@ namespace AdventuresOfBlink.Data
         public int bonusLogic;
         public int bonusEnergy;
 
+        [Header("Runtime Values")]
+        [Tooltip("Current energy available for abilities.")]
+        public int currentEnergy;
+
         [Header("Percentage Modifiers")]
         public float percentMaxHealth;
         public float percentAttack;
@@ -53,6 +57,7 @@ namespace AdventuresOfBlink.Data
             baseSpeed = source.speed;
             baseLogic = source.logic;
             baseEnergy = source.energy;
+            currentEnergy = Energy;
         }
 
         public int MaxHealth => Mathf.RoundToInt((baseMaxHealth + bonusMaxHealth) * (1f + percentMaxHealth));
@@ -61,5 +66,16 @@ namespace AdventuresOfBlink.Data
         public int Speed => Mathf.RoundToInt((baseSpeed + bonusSpeed) * (1f + percentSpeed));
         public int Logic => Mathf.RoundToInt((baseLogic + bonusLogic) * (1f + percentLogic));
         public int Energy => Mathf.RoundToInt((baseEnergy + bonusEnergy) * (1f + percentEnergy));
+
+        /// <summary>
+        /// Consumes energy if available and returns true on success.
+        /// </summary>
+        public bool ConsumeEnergy(int amount)
+        {
+            if (currentEnergy < amount)
+                return false;
+            currentEnergy -= amount;
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `energyCost` field to `AbilityData`
- track current energy on `RuntimeStats` and expose a `ConsumeEnergy` helper
- subtract energy in `PlasmaSword` before playing the attack animation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685cd4263614832881a1d117b9e2191f