### PR TITLE
Improve damage formula

### DIFF
--- a/Assets/Scripts/Combat/BattleFormula.cs
+++ b/Assets/Scripts/Combat/BattleFormula.cs
@@ -10,8 +10,19 @@ namespace AdventuresOfBlink.Combat
     {
         public static float CalculateDamage(RuntimeStats attacker, RuntimeStats defender, AbilityData ability)
         {
-            float attackPower = attacker.Attack + ability.baseDamage;
-            float damage = attackPower - defender.Defense;
+            if (attacker == null || defender == null || ability == null)
+                return 0f;
+
+            float attack = UnityEngine.Mathf.Max(1f, attacker.Attack);
+            float defense = UnityEngine.Mathf.Max(1f, defender.Defense);
+
+            // Base scaling based on attacker's power and defender's toughness
+            float scaledDamage = (attack / defense) * ability.baseDamage;
+
+            // Apply ±10% random jitter to prevent perfectly deterministic combat
+            float jitter = UnityEngine.Random.Range(0.9f, 1.1f);
+
+            float damage = scaledDamage * jitter;
             return UnityEngine.Mathf.Max(1f, damage);
         }
     }

--- a/Assets/Tests/EditMode/BattleFormulaTests.cs
+++ b/Assets/Tests/EditMode/BattleFormulaTests.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using UnityEngine;
+using AdventuresOfBlink.Data;
+using AdventuresOfBlink.Combat;
+
+public class BattleFormulaTests
+{
+    [Test]
+    public void CalculateDamage_JitterWithinTenPercent()
+    {
+        var ability = ScriptableObject.CreateInstance<AbilityData>();
+        ability.baseDamage = 10f;
+
+        var attacker = new RuntimeStats { baseAttack = 10 };
+        var defender = new RuntimeStats { baseDefense = 10 };
+
+        float expected = (attacker.Attack / (float)defender.Defense) * ability.baseDamage;
+
+        for (int i = 0; i < 50; i++)
+        {
+            Random.InitState(i);
+            float damage = BattleFormula.CalculateDamage(attacker, defender, ability);
+            Assert.GreaterOrEqual(damage, expected * 0.9f);
+            Assert.LessOrEqual(damage, expected * 1.1f);
+        }
+    }
+
+    [Test]
+    public void CalculateDamage_ScalesWithAttack()
+    {
+        var ability = ScriptableObject.CreateInstance<AbilityData>();
+        ability.baseDamage = 10f;
+
+        var attacker1 = new RuntimeStats { baseAttack = 10 };
+        var attacker2 = new RuntimeStats { baseAttack = 20 };
+        var defender = new RuntimeStats { baseDefense = 5 };
+
+        Random.InitState(0);
+        float dmg1 = BattleFormula.CalculateDamage(attacker1, defender, ability);
+        Random.InitState(0);
+        float dmg2 = BattleFormula.CalculateDamage(attacker2, defender, ability);
+
+        Assert.AreEqual(dmg1 * 2f, dmg2, 0.001f);
+    }
+}


### PR DESCRIPTION
## Summary
- adjust `BattleFormula` to scale attack vs defense and apply jitter
- add edit mode tests for damage formula jitter and scaling

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d289933308328abda83dda86ad258