### PR TITLE
Add Resources folders and update asset docs

### DIFF
--- a/Assets/Documentation/SetupGuide.md
+++ b/Assets/Documentation/SetupGuide.md
@@ -51,6 +51,7 @@ This guide outlines how to configure core systems in **Adventures of Blink**. Fo
    - **InventoryPanel** – also assign the same `InventorySystem` for listing items.
    - **UpgradePanel** – requires an `UpgradeSystem` (see below) but will also reference the inventory through that system.
    - For a walkthrough of each UI component see [UI Panels Guide](UIPanelsGuide.md).
+3. Place your `ItemData` assets under `Assets/Resources/Items` and `AbilityData` assets under `Assets/Resources/Abilities`. This allows `SaveUtility` to locate them using `Resources.Load`.
 
 ## World Managers
 1. Place a `DayNightCycle` component in the scene to animate lighting throughout the day.

--- a/Assets/Resources/Abilities/README.txt
+++ b/Assets/Resources/Abilities/README.txt
@@ -1,0 +1,1 @@
+Place AbilityData assets here.

--- a/Assets/Resources/Items/README.txt
+++ b/Assets/Resources/Items/README.txt
@@ -1,0 +1,1 @@
+Place ItemData assets here.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ The `SaveGame` component persists the player's inventory and upgrade levels.
 2. Assign your scene's `InventorySystem` and `DukeController` to the fields.
 Data is stored as JSON at `Application.persistentDataPath/save.json` using
 `SaveUtility`.
+Item and ability ScriptableObjects must be placed under `Assets/Resources/Items`
+and `Assets/Resources/Abilities` respectively so they can be loaded when a save
+game is restored.


### PR DESCRIPTION
## Summary
- add `Resources/Items` and `Resources/Abilities` folders
- document data asset placement in SetupGuide and README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2bed037083288f199f7507f329d0