### PR TITLE
Add manual dock setup section

### DIFF
--- a/Assets/Documentation/DockGuide.md
+++ b/Assets/Documentation/DockGuide.md
@@ -8,6 +8,20 @@ This guide explains how to add and configure the dock UI used for quick access t
 3. Expand the **slots** list on `DockPanel` and link each child `DockSlotUI` in order from left to right.
 4. Each child named *Slot* already has a `DockSlotUI` component with a preset `slotIndex`. Verify the indices start at `0` so the dock updates correctly.
 
+## Building the Dock Manually
+Follow these steps if you want to construct the dock without using the prefab:
+1. Create a `Canvas` and under it add a `Panel` named `Dock`.
+   - Anchor the panel to the bottom center of the screen (set **Anchor Min** and **Anchor Max** to `(0.5, 0)` and pivot to `(0.5, 0)`).
+   - Resize the panel so it has enough width for all slots in a row.
+2. Add child objects for each slot you need, for example `Slot1`, `Slot2`, etc.
+   - Position them evenly across the panel or use a layout group.
+3. On each slot, add an `Image` component to display the icon and attach the `DockSlotUI` script.
+   - Drag the slot's `Image` into the **icon** field of `DockSlotUI` and set **slotIndex** starting at `0`.
+4. Select the root **Dock** object and add the `DockPanel` component.
+   - Assign your scene's `InventorySystem` to **inventory**.
+   - Size the **slots** array and drag each `DockSlotUI` from the child slots into the list.
+
+
 ## Drag and Drop Behaviour
 1. `DockSlotUI` implements Unity drag interfaces and works together with the static `DragPayload` class.
 2. When dragging begins, the slot stores its ability or item in `DragPayload` along with a reference to the source slot.


### PR DESCRIPTION
## Summary
- extend DockGuide with instructions on manually constructing the dock

## Testing
- `scripts/run-tests.sh` *(fails: UNITY_LICENSE environment variable must contain a valid Unity license)*

------
https://chatgpt.com/codex/tasks/task_e_685d2f24ece883288bcaa8f4f6e550f2