### PR TITLE
Fix Input Actions JSON syntax

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -512,7 +512,7 @@
                     "action": "CycleTarget",
                     "isComposite": false,
                     "isPartOfComposite": false
-                }
+                },
                 {
                     "name": "",
                     "id": "3b3ed86d-12b5-4197-82b7-b5d7f6b10cc0",
@@ -534,7 +534,7 @@
                     "action": "SwitchForm",
                     "isComposite": false,
                     "isPartOfComposite": false
-                },
+                }
             ]
         },
         {


### PR DESCRIPTION
## Summary
- fix missing comma in `InputSystem_Actions.inputactions`
- remove trailing comma in the same list

## Testing
- `jq . Assets/InputSystem_Actions.inputactions`
- `./scripts/run-tests.sh` *(fails: UNITY_LICENSE environment variable must contain a valid Unity license)*

------
https://chatgpt.com/codex/tasks/task_e_685dc0c427b48328beacf8e9ab47a5e9