### PR TITLE
Decouple health from targeting

### DIFF
--- a/Assets/Documentation/SetupGuide.md
+++ b/Assets/Documentation/SetupGuide.md
@@ -73,7 +73,7 @@ Add these components to your scene for full functionality:
 
 ## Targeting System
 1. Add a `TargetingSystem` component to the player or a persistent manager object.
-2. Attach `Targetable` to each enemy or NPC and set their **displayName** and optional `RuntimeStats`.
+2. Attach `Targetable` to each enemy or NPC and set their **displayName**. Add a `Health` component if the object has hit points.
 3. Create a panel named `TargetPanel` and attach the `TargetPanel` script.
    - Assign your `TargetingSystem` and hook up the name and health UI elements.
 4. Press **Tab** in play mode to cycle between nearby targets. See [Targeting Guide](TargetingGuide.md) for full details.

--- a/Assets/Documentation/TargetingGuide.md
+++ b/Assets/Documentation/TargetingGuide.md
@@ -4,7 +4,7 @@ This guide explains how to configure the targeting system so the player can cycl
 
 ## Setup Steps
 1. Add the `TargetingSystem` component to your player or a persistent manager object.
-2. On each enemy or NPC, attach `Targetable` and fill in **displayName**. Assign a `RuntimeStats` reference if health should be displayed.
+2. On each enemy or NPC, attach `Targetable` and fill in **displayName**. Add a `Health` component if the target should display hit points.
 3. Create a panel named `TargetPanel` under your canvas.
    - Add a `TMP_Text` element for the name display and a `Slider` for health.
    - Attach the `TargetPanel` script and assign the `TargetingSystem`, `TMP_Text`, and `Slider` fields.

--- a/Assets/Documentation/UIPanelsGuide.md
+++ b/Assets/Documentation/UIPanelsGuide.md
@@ -56,7 +56,7 @@ Dock slots update automatically through the `InventorySystem.InventoryChanged` e
 1. Make a prefab with a `Slider` UI element sized to your liking.
 2. Attach `HealthBar` and assign:
    - **slider** – the slider component.
-   - **stats** – `RuntimeStats` of the actor.
+   - **health** – the actor's `Health` component.
    - **blinkTransform** – optional; Blink's transform for visibility range.
 3. Set **alwaysVisible** if you want the bar shown regardless of distance.
 

--- a/Assets/Scripts/Combat/Health.cs
+++ b/Assets/Scripts/Combat/Health.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+
+namespace AdventuresOfBlink.Combat
+{
+    /// <summary>
+    /// Simple component storing current and maximum health.
+    /// Other systems apply damage or healing through this API.
+    /// </summary>
+    public class Health : MonoBehaviour
+    {
+        [Tooltip("Maximum health value at full health.")]
+        public int maxHealth = 100;
+
+        [Tooltip("Current health value.")]
+        public int currentHealth;
+
+        /// <summary>
+        /// Invoked when health changes with (current, max).
+        /// </summary>
+        public event System.Action<int, int> HealthChanged;
+
+        private void Awake()
+        {
+            currentHealth = Mathf.Clamp(currentHealth, 0, maxHealth);
+            HealthChanged?.Invoke(currentHealth, maxHealth);
+        }
+
+        /// <summary>
+        /// Decreases health by the given amount.
+        /// </summary>
+        public void ApplyDamage(int amount)
+        {
+            currentHealth = Mathf.Max(0, currentHealth - amount);
+            HealthChanged?.Invoke(currentHealth, maxHealth);
+        }
+
+        /// <summary>
+        /// Restores health up to the maximum value.
+        /// </summary>
+        public void Heal(int amount)
+        {
+            currentHealth = Mathf.Min(maxHealth, currentHealth + amount);
+            HealthChanged?.Invoke(currentHealth, maxHealth);
+        }
+
+        /// <summary>
+        /// Returns the current health ratio 0-1.
+        /// </summary>
+        public float Ratio => maxHealth > 0 ? (float)currentHealth / maxHealth : 0f;
+    }
+}

--- a/Assets/Scripts/Combat/PlasmaSword.cs
+++ b/Assets/Scripts/Combat/PlasmaSword.cs
@@ -108,6 +108,9 @@ namespace AdventuresOfBlink.Combat
             if (attacker != null && target != null)
             {
                 float damage = BattleFormula.CalculateDamage(attacker, target, ability);
+                Health health = target.GetComponent<Health>();
+                if (health != null)
+                    health.ApplyDamage(Mathf.RoundToInt(damage));
                 Debug.Log($"PlasmaSword dealt {damage} damage with {ability.abilityName}");
             }
         }

--- a/Assets/Scripts/Targeting/Targetable.cs
+++ b/Assets/Scripts/Targeting/Targetable.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using AdventuresOfBlink.Data;
 
 namespace AdventuresOfBlink.Targeting
 {
@@ -11,7 +10,5 @@ namespace AdventuresOfBlink.Targeting
         [Tooltip("Name shown in the UI when this object is targeted.")]
         public string displayName;
 
-        [Tooltip("Optional stats associated with this target.")]
-        public RuntimeStats stats;
     }
 }

--- a/Assets/Scripts/UI/HealthBar.cs
+++ b/Assets/Scripts/UI/HealthBar.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-using AdventuresOfBlink.Data;
+using AdventuresOfBlink.Combat;
 
 namespace AdventuresOfBlink.UI
 {
@@ -13,11 +13,8 @@ namespace AdventuresOfBlink.UI
         [Tooltip("Slider UI element used to show health percentage.")]
         public Slider slider;
 
-        [Tooltip("Character stats providing max health.")]
-        public RuntimeStats stats;
-
-        [Tooltip("Current health value.")]
-        public int currentHealth;
+        [Tooltip("Health component providing values.")]
+        public Health health;
 
         [Tooltip("Transform of Blink used to determine visibility range.")]
         public Transform blinkTransform;
@@ -30,9 +27,15 @@ namespace AdventuresOfBlink.UI
 
         private void Awake()
         {
-            if (stats != null)
-                currentHealth = stats.MaxHealth;
+            if (health != null)
+                health.HealthChanged += OnHealthChanged;
             UpdateBar();
+        }
+
+        private void OnDestroy()
+        {
+            if (health != null)
+                health.HealthChanged -= OnHealthChanged;
         }
 
         private void Update()
@@ -48,31 +51,13 @@ namespace AdventuresOfBlink.UI
             UpdateBar();
         }
 
-        /// <summary>
-        /// Applies damage and refreshes the UI.
-        /// </summary>
-        public void ApplyDamage(int amount)
-        {
-            currentHealth = Mathf.Max(0, currentHealth - amount);
-            UpdateBar();
-        }
-
-        /// <summary>
-        /// Restores health up to the maximum value.
-        /// </summary>
-        public void Heal(int amount)
-        {
-            int max = stats != null ? stats.MaxHealth : currentHealth;
-            currentHealth = Mathf.Min(max, currentHealth + amount);
-            UpdateBar();
-        }
+        private void OnHealthChanged(int current, int max) => UpdateBar();
 
         private void UpdateBar()
         {
-            if (slider == null)
+            if (slider == null || health == null)
                 return;
-            int max = stats != null ? stats.MaxHealth : currentHealth;
-            slider.value = max > 0 ? (float)currentHealth / max : 0f;
+            slider.value = health.Ratio;
         }
     }
 }

--- a/Assets/Scripts/UI/TargetPanel.cs
+++ b/Assets/Scripts/UI/TargetPanel.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using AdventuresOfBlink.Targeting;
+using AdventuresOfBlink.Combat;
 
 namespace AdventuresOfBlink.UI
 {
@@ -18,6 +19,8 @@ namespace AdventuresOfBlink.UI
 
         [Tooltip("Slider displaying target health.")]
         public Slider healthSlider;
+
+        private Health targetHealth;
 
         private void OnEnable()
         {
@@ -39,17 +42,17 @@ namespace AdventuresOfBlink.UI
 
             if (healthSlider != null)
             {
-                if (target != null && target.stats != null)
-                {
-                    healthSlider.value = 1f;
-                    healthSlider.gameObject.SetActive(true);
-                }
-                else
-                {
-                    healthSlider.value = 0f;
-                    healthSlider.gameObject.SetActive(false);
-                }
+                targetHealth = target != null ? target.GetComponent<Health>() : null;
+                bool hasHealth = targetHealth != null;
+                healthSlider.gameObject.SetActive(hasHealth);
+                healthSlider.value = hasHealth ? targetHealth.Ratio : 0f;
             }
+        }
+
+        private void Update()
+        {
+            if (healthSlider != null && targetHealth != null)
+                healthSlider.value = targetHealth.Ratio;
         }
     }
 }

--- a/Assets/Tests/EditMode/HealthAndTargetingTests.cs
+++ b/Assets/Tests/EditMode/HealthAndTargetingTests.cs
@@ -1,0 +1,77 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+using AdventuresOfBlink.Targeting;
+using AdventuresOfBlink.UI;
+using AdventuresOfBlink.Combat;
+
+public class HealthAndTargetingTests
+{
+    [Test]
+    public void CycleTarget_WorksWithoutHealthComponent()
+    {
+        var player = new GameObject("Player");
+        var system = player.AddComponent<TargetingSystem>();
+
+        var targetObj = new GameObject("Target");
+        var target = targetObj.AddComponent<Targetable>();
+        targetObj.transform.position = Vector3.one;
+
+        system.CycleTarget();
+        Assert.AreEqual(target, system.CurrentTarget);
+    }
+
+    [Test]
+    public void TargetPanel_DisplaysHealthRatio()
+    {
+        var systemObj = new GameObject("System");
+        var system = systemObj.AddComponent<TargetingSystem>();
+
+        var targetObj = new GameObject("Enemy");
+        targetObj.transform.position = Vector3.one;
+        var target = targetObj.AddComponent<Targetable>();
+        target.displayName = "Enemy";
+        var health = targetObj.AddComponent<Health>();
+        health.maxHealth = 100;
+        health.currentHealth = 50;
+
+        var panelObj = new GameObject("Panel");
+        var text = panelObj.AddComponent<TextMeshProUGUI>();
+        var slider = panelObj.AddComponent<Slider>();
+        var panel = panelObj.AddComponent<TargetPanel>();
+        panel.targetingSystem = system;
+        panel.nameText = text;
+        panel.healthSlider = slider;
+        panel.OnEnable();
+
+        system.CycleTarget();
+        Assert.AreEqual("Enemy", text.text);
+        Assert.AreEqual(0.5f, slider.value, 0.001f);
+    }
+
+    [Test]
+    public void HealthBar_UpdatesWhenHealthChanges()
+    {
+        var obj = new GameObject("Target");
+        var health = obj.AddComponent<Health>();
+        health.maxHealth = 100;
+        health.currentHealth = 100;
+
+        var sliderObj = new GameObject("Slider");
+        var slider = sliderObj.AddComponent<Slider>();
+        var bar = sliderObj.AddComponent<HealthBar>();
+        bar.slider = slider;
+        bar.health = health;
+        bar.alwaysVisible = true;
+
+        typeof(HealthBar).GetMethod("Awake", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .Invoke(bar, null);
+
+        Assert.AreEqual(1f, slider.value, 0.001f);
+
+        health.ApplyDamage(30);
+        bar.Update();
+        Assert.AreEqual(0.7f, slider.value, 0.001f);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce generic `Health` component
- remove `RuntimeStats` from `Targetable`
- connect `HealthBar` and `TargetPanel` to the new health component
- apply damage in `PlasmaSword`
- update setup guides and add unit tests

## Testing
- `./scripts/run-tests.sh` *(fails: UNITY_LICENSE environment variable must contain a valid Unity license)*

------
https://chatgpt.com/codex/tasks/task_e_685e7ec059c88328b38348750563dad9