### PR TITLE
docs: link world building guide

### DIFF
--- a/Assets/Documentation/SetupGuide.md
+++ b/Assets/Documentation/SetupGuide.md
@@ -26,6 +26,7 @@ The project relies on several Unity packages. Ensure these appear in `Packages/m
 - `com.unity.probuilder` – level prototyping.
 - `com.unity.cinemachine` – advanced camera control.
 - `com.unity.postprocessing` – post‑processing effects.
+- `com.unity.terrain-tools` – terrain editing utilities.
 
 ### Additional systems
 
@@ -118,6 +119,8 @@ Save this file inside the `Assets` folder so Unity imports it as a `TextAsset` a
 1. Install the **ProBuilder** package from the package manager.
 2. Use ProBuilder shapes to block out buildings and streets. Save meshes to the `Assets/Models` folder for reuse.
 3. Example models `NeonSign.obj` and `WallPanel.obj` demonstrate simple planes for signage and walls.
+4. See the [World Building Guide](WorldBuildingGuide.md) for detailed terrain and
+   modular construction steps.
 
 ## Cinemachine Camera
 1. Add a `CinemachineBrain` component to the main camera.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The project is in early setup. The vision includes hack-and-slash battles with a
 1. Clone or download this repository.
 2. In Unity Hub, click **Add project** and select the cloned folder.
 3. Open with **Unity 6.1.0f1**.
+4. Follow the [Setup Guide](Assets/Documentation/SetupGuide.md) for scene
+   configuration and see the [World Building Guide](Assets/Documentation/WorldBuildingGuide.md)
+   for terrain and level layout tips.
 
 All gameplay assets and scripts will live under the `Assets/` folder. Subfolders such as `Scripts/` and `Art/` will grow as new systems are introduced.
 


### PR DESCRIPTION
## Summary
- mention Setup Guide and World Building Guide in README
- recommend `com.unity.terrain-tools` and link the World Building Guide from SetupGuide

## Testing
- `bash scripts/run-tests.sh` *(fails: UNITY_LICENSE environment variable must contain a valid Unity license)*

------
https://chatgpt.com/codex/tasks/task_e_685e8ab175bc8328b52d8c4eb9361913