### PR TITLE
Add WorldItem pickup and drop system

### DIFF
--- a/Assets/Documentation/SetupGuide.md
+++ b/Assets/Documentation/SetupGuide.md
@@ -86,6 +86,7 @@ Add these components to your scene for full functionality:
    - **UpgradePanel** – requires an `UpgradeSystem` (see below) but will also reference the inventory through that system.
    - For a walkthrough of each UI component see [UI Panels Guide](UIPanelsGuide.md).
 3. Place your `ItemData` assets under `Assets/Resources/Items` and `AbilityData` assets under `Assets/Resources/Abilities`. This allows `SaveUtility` to locate them using `Resources.Load`.
+4. Right-click any item slot in the inventory to open a context menu and select **Drop Item**. The item spawns in front of the player as a `WorldItem` that can be picked up later. Right-click a `WorldItem` in the scene and choose **Pick Up** to collect it.
 
 ## World Managers
 1. Place a `DayNightCycle` component in the scene to animate lighting throughout the day.

--- a/Assets/Scripts/UI/ContextMenuUtility.cs
+++ b/Assets/Scripts/UI/ContextMenuUtility.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+using TMPro;
+
+namespace AdventuresOfBlink.UI
+{
+    /// <summary>
+    /// Utility for spawning a very simple one-button context menu
+    /// at the specified screen position.
+    /// </summary>
+    public static class ContextMenuUtility
+    {
+        public static void Show(string optionLabel, UnityAction callback, Vector2 position)
+        {
+            Canvas canvas = Object.FindObjectOfType<Canvas>();
+            if (canvas == null)
+                return;
+
+            GameObject panel = new GameObject("ContextMenu", typeof(RectTransform), typeof(Image));
+            panel.transform.SetParent(canvas.transform, false);
+            RectTransform rect = panel.GetComponent<RectTransform>();
+            rect.pivot = new Vector2(0, 1);
+            rect.sizeDelta = new Vector2(120, 30);
+            rect.position = position;
+
+            GameObject buttonObj = new GameObject("Option", typeof(RectTransform), typeof(Button), typeof(Image));
+            buttonObj.transform.SetParent(panel.transform, false);
+            RectTransform br = buttonObj.GetComponent<RectTransform>();
+            br.anchorMin = Vector2.zero;
+            br.anchorMax = Vector2.one;
+            br.offsetMin = Vector2.zero;
+            br.offsetMax = Vector2.zero;
+
+            GameObject textObj = new GameObject("Text", typeof(RectTransform), typeof(TMP_Text));
+            textObj.transform.SetParent(buttonObj.transform, false);
+            RectTransform tr = textObj.GetComponent<RectTransform>();
+            tr.anchorMin = Vector2.zero;
+            tr.anchorMax = Vector2.one;
+            tr.offsetMin = Vector2.zero;
+            tr.offsetMax = Vector2.zero;
+            TMP_Text text = textObj.GetComponent<TMP_Text>();
+            text.text = optionLabel;
+            text.alignment = TextAlignmentOptions.Center;
+            text.raycastTarget = false;
+
+            Button btn = buttonObj.GetComponent<Button>();
+            btn.onClick.AddListener(callback);
+            btn.onClick.AddListener(() => Object.Destroy(panel));
+        }
+    }
+}

--- a/Assets/Scripts/UI/InventoryPanel.cs
+++ b/Assets/Scripts/UI/InventoryPanel.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using AdventuresOfBlink;
 
 namespace AdventuresOfBlink.UI
 {
@@ -16,6 +17,9 @@ namespace AdventuresOfBlink.UI
 
         [Tooltip("Prefab used for each item entry in the UI.")]
         public GameObject itemSlotPrefab;
+
+        [Tooltip("World item prefab used when dropping from the inventory.")]
+        public GameObject worldItemPrefab;
 
         private void OnEnable()
         {
@@ -46,7 +50,11 @@ namespace AdventuresOfBlink.UI
                 GameObject go = Instantiate(itemSlotPrefab, contentRoot);
                 ItemSlotUI slot = go.GetComponent<ItemSlotUI>();
                 if (slot != null)
+                {
+                    slot.inventory = inventory;
+                    slot.worldItemPrefab = worldItemPrefab;
                     slot.Setup(item.data, item.quantity);
+                }
             }
         }
     }

--- a/Assets/Scripts/UI/ItemSlotUI.cs
+++ b/Assets/Scripts/UI/ItemSlotUI.cs
@@ -3,16 +3,24 @@ using UnityEngine.UI;
 using TMPro;
 using UnityEngine.EventSystems;
 using AdventuresOfBlink.Data;
+using AdventuresOfBlink.World;
+using AdventuresOfBlink;
 
 namespace AdventuresOfBlink.UI
 {
     /// <summary>
     /// Displays a single item entry with icon and quantity text.
     /// </summary>
-    public class ItemSlotUI : MonoBehaviour, IBeginDragHandler, IEndDragHandler
+public class ItemSlotUI : MonoBehaviour, IBeginDragHandler, IEndDragHandler, IPointerClickHandler
     {
         public Image icon;
         public TMP_Text quantityText;
+
+        [Tooltip("Inventory used for drop actions.")]
+        public InventorySystem inventory;
+
+        [Tooltip("Prefab spawned when dropping an item.")]
+        public GameObject worldItemPrefab;
 
         private ItemData itemData;
 
@@ -45,6 +53,36 @@ namespace AdventuresOfBlink.UI
         public void OnEndDrag(PointerEventData eventData)
         {
             DragPayload.Clear();
+        }
+
+        /// <summary>
+        /// Shows a context menu when right-clicked allowing the item to be dropped.
+        /// </summary>
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (eventData.button != PointerEventData.InputButton.Right || itemData == null)
+                return;
+
+            if (inventory == null || worldItemPrefab == null)
+                return;
+
+            ContextMenuUtility.Show("Drop Item", DropItem, eventData.position);
+        }
+
+        private void DropItem()
+        {
+            if (inventory.RemoveItem(itemData))
+            {
+                GameObject player = GameObject.FindGameObjectWithTag("Player");
+                Vector3 pos = player != null ? player.transform.position + player.transform.forward * 2f : Vector3.zero;
+                GameObject go = Instantiate(worldItemPrefab, pos, Quaternion.identity);
+                WorldItem wi = go.GetComponent<WorldItem>();
+                if (wi != null)
+                {
+                    wi.itemData = itemData;
+                    wi.quantity = 1;
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/World/WorldItem.cs
+++ b/Assets/Scripts/World/WorldItem.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using AdventuresOfBlink.Data;
+
+namespace AdventuresOfBlink.World
+{
+    /// <summary>
+    /// Represents an item that exists in the world and can be picked up
+    /// by the player.
+    /// </summary>
+    public class WorldItem : MonoBehaviour, IPointerClickHandler
+    {
+        [Tooltip("Item represented by this world object.")]
+        public ItemData itemData;
+
+        [Tooltip("Quantity granted when picked up.")]
+        public int quantity = 1;
+
+        /// <summary>
+        /// Adds the item to the provided inventory and destroys this object.
+        /// </summary>
+        public void PickUp(InventorySystem inventory)
+        {
+            if (inventory == null || itemData == null)
+                return;
+
+            inventory.AddItem(itemData, quantity);
+            Destroy(gameObject);
+        }
+
+        /// <summary>
+        /// Displays a context menu when right-clicked in the world.
+        /// </summary>
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (eventData.button != PointerEventData.InputButton.Right)
+                return;
+
+            InventorySystem inventory = FindObjectOfType<InventorySystem>();
+            if (inventory == null)
+                return;
+
+            UI.ContextMenuUtility.Show("Pick Up", () => PickUp(inventory), eventData.position);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/WorldItemTests.cs
+++ b/Assets/Tests/EditMode/WorldItemTests.cs
@@ -1,0 +1,28 @@
+using NUnit.Framework;
+using UnityEngine;
+using AdventuresOfBlink;
+using AdventuresOfBlink.World;
+using AdventuresOfBlink.Data;
+
+public class WorldItemTests
+{
+    [Test]
+    public void PickUp_AddsItemAndDestroysObject()
+    {
+        var item = ScriptableObject.CreateInstance<ItemData>();
+        var inventoryObj = new GameObject("Inventory");
+        var inventory = inventoryObj.AddComponent<InventorySystem>();
+
+        var go = new GameObject("WorldItem");
+        var worldItem = go.AddComponent<WorldItem>();
+        worldItem.itemData = item;
+        worldItem.quantity = 2;
+
+        worldItem.PickUp(inventory);
+
+        Assert.AreEqual(1, inventory.items.Count);
+        Assert.AreEqual(item, inventory.items[0].data);
+        Assert.AreEqual(2, inventory.items[0].quantity);
+        Assert.IsTrue(worldItem == null);
+    }
+}


### PR DESCRIPTION
## Summary
- add `WorldItem` component for items in the world
- create `ContextMenuUtility` for simple runtime context menus
- expand `ItemSlotUI` to allow dropping items via right-click
- supply world item prefab reference in `InventoryPanel`
- document how to drop and pick up items
- test that `WorldItem.PickUp` adds to the inventory and destroys the item

## Testing
- `scripts/run-tests.sh` *(fails: UNITY_LICENSE environment variable must contain a valid Unity license)*

------
https://chatgpt.com/codex/tasks/task_e_685e8b00b17c832894c7da90f15f2d85