### PR TITLE
Update local test scripts to use project Unity version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ Data is stored as JSON at `Application.persistentDataPath/save.json` using
 
 ## Local Test Setup
 Edit Mode unit tests can be executed using Docker. First run `scripts/setup.sh`
-to pull the Unity editor image. Then set your `UNITY_LICENSE` environment
-variable and execute `scripts/run-tests.sh`.
+to pull the Unity editor image. The helper scripts automatically read the Unity
+version from `ProjectSettings/ProjectVersion.txt`, so the container always
+matches your project. After setup, set the `UNITY_LICENSE` environment variable
+and execute `scripts/run-tests.sh`.
 
 Item and ability ScriptableObjects must be placed under `Assets/Resources/Items`
 and `Assets/Resources/Abilities` respectively so they can be loaded when a save

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2,7 +2,12 @@
 # Execute Unity Edit Mode tests inside a Docker container
 set -e
 
-UNITY_VERSION="2022.3.0f1"
+PROJECT_VERSION_FILE="${PROJECT_VERSION_FILE:-ProjectSettings/ProjectVersion.txt}"
+if [[ -f "$PROJECT_VERSION_FILE" ]]; then
+    UNITY_VERSION=$(grep m_EditorVersion "$PROJECT_VERSION_FILE" | awk '{print $2}')
+else
+    UNITY_VERSION="2022.3.0f1"
+fi
 IMAGE="unityci/editor:${UNITY_VERSION}-base-0"
 
 PROJECT_PATH="/project"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,8 +7,14 @@ if ! command -v docker >/dev/null 2>&1; then
     exit 1
 fi
 
-# Default Unity version and image tag used for local test runs
-UNITY_VERSION="2022.3.0f1"
+# Determine Unity version from the project settings so the image
+# always matches the editor used by the project.
+PROJECT_VERSION_FILE="${PROJECT_VERSION_FILE:-ProjectSettings/ProjectVersion.txt}"
+if [[ -f "$PROJECT_VERSION_FILE" ]]; then
+    UNITY_VERSION=$(grep m_EditorVersion "$PROJECT_VERSION_FILE" | awk '{print $2}')
+else
+    UNITY_VERSION="2022.3.0f1"
+fi
 IMAGE="unityci/editor:${UNITY_VERSION}-base-0"
 
 # Pull the Unity editor image if it does not exist locally


### PR DESCRIPTION
## Summary
- pull the Unity version from `ProjectSettings/ProjectVersion.txt` in setup scripts
- clarify README instructions about test scripts

## Testing
- `./scripts/run-tests.sh` *(fails: UNITY_LICENSE environment variable must contain a valid Unity license)*
- `./scripts/setup.sh` *(fails: Docker is required to run tests. Please install Docker and rerun.)*

------
https://chatgpt.com/codex/tasks/task_e_685e8d0424c88328b7d7e9f34808d014