### PR TITLE
Update PlasmaSword target references

### DIFF
--- a/Assets/Scripts/Combat/PlasmaSword.cs
+++ b/Assets/Scripts/Combat/PlasmaSword.cs
@@ -22,8 +22,11 @@ namespace AdventuresOfBlink.Combat
         [Tooltip("Stats of the attacker performing the combo.")]
         public RuntimeStats attacker;
 
-        [Tooltip("Optional stats of the current target receiving damage.")]
-        public RuntimeStats target;
+        [Tooltip("Stats of the current target receiving damage.")]
+        public RuntimeStats targetStats;
+
+        [Tooltip("Health component of the current target.")]
+        public Health targetHealth;
 
         [Tooltip("Multiplier applied to attack speed from upgrades.")]
         public float speedMultiplier = 1f;
@@ -105,12 +108,10 @@ namespace AdventuresOfBlink.Combat
                 animator.Play(ability.animationClip.name);
             }
 
-            if (attacker != null && target != null)
+            if (attacker != null && targetStats != null && targetHealth != null)
             {
-                float damage = BattleFormula.CalculateDamage(attacker, target, ability);
-                Health health = target.GetComponent<Health>();
-                if (health != null)
-                    health.ApplyDamage(Mathf.RoundToInt(damage));
+                float damage = BattleFormula.CalculateDamage(attacker, targetStats, ability);
+                targetHealth.ApplyDamage(Mathf.RoundToInt(damage));
                 Debug.Log($"PlasmaSword dealt {damage} damage with {ability.abilityName}");
             }
         }


### PR DESCRIPTION
## Summary
- break out PlasmaSword target stats and health
- use the new fields when applying damage

## Testing
- `scripts/run-tests.sh` *(fails: UNITY_LICENSE environment variable must contain a valid Unity license)*

------
https://chatgpt.com/codex/tasks/task_e_685e90790ca88328b5a2ca35b7a20b23