### PR TITLE
Switch UpgradeEntryUI to TMP_Text

### DIFF
--- a/Assets/Documentation/UIPanelsGuide.md
+++ b/Assets/Documentation/UIPanelsGuide.md
@@ -48,7 +48,7 @@ Dock slots update automatically through the `InventorySystem.InventoryChanged` e
    - Assign **entryPrefab** as described below.
    - Fill **availableUpgrades** with `UpgradeData` assets.
 4. Create an upgrade entry prefab:
-   - Include an `Image` for the icon, two `Text` components for the name and cost, and a `Button`.
+   - Include an `Image` for the icon, two **TMP_Text** components for the name and cost, and a `Button`.
    - Attach `UpgradeEntryUI` and link its fields.
 5. `UpgradePanel` populates entries on enable and each button calls `UpgradeSystem.ApplyUpgrade`. The upgrade system references the same `InventorySystem` to deduct materials and unlock abilities.
 

--- a/Assets/Scripts/UI/UpgradeEntryUI.cs
+++ b/Assets/Scripts/UI/UpgradeEntryUI.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 using AdventuresOfBlink.Data;
 using AdventuresOfBlink.Systems;
 
@@ -12,8 +13,8 @@ namespace AdventuresOfBlink.UI
     public class UpgradeEntryUI : MonoBehaviour
     {
         public Image icon;
-        public Text nameText;
-        public Text costText;
+        public TMP_Text nameText;
+        public TMP_Text costText;
         public Button upgradeButton;
 
         private UpgradeData data;


### PR DESCRIPTION
## Summary
- migrate UpgradeEntryUI fields from `UnityEngine.UI.Text` to `TMP_Text`
- update the UI Panels guide to mention TMP components for upgrade entries

## Testing
- `./scripts/run-tests.sh` *(fails: UNITY_LICENSE environment variable must contain a valid Unity license)*

------
https://chatgpt.com/codex/tasks/task_e_685e91485890832882fd96f21a2e1cdc